### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,5 +1,8 @@
 name: Validate Configs
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/rodrigobprado/Home-Security-DIY/security/code-scanning/1](https://github.com/rodrigobprado/Home-Security-DIY/security/code-scanning/1)

To fix the problem, explicitly declare minimal `GITHUB_TOKEN` permissions for this workflow. Since all jobs just check out code and run local tools, they only need read access to repository contents. The best, non-invasive fix is to add a root-level `permissions` block with `contents: read`. This applies to all jobs that don’t override it, which matches our needs and avoids changing job behavior.

Concretely:
- Edit `.github/workflows/validate.yml`.
- Insert a `permissions:` section near the top of the file (e.g., after `name: Validate Configs` and before `on:`).
- Set `contents: read` as the only permission, because none of the jobs require write access or other scopes.

No additional methods, imports, or definitions are needed; this is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
