### PR TITLE
fix: resolve medium issues #14 #15 #16 #17 #18 #19 #20 #21 #22 #28 #38 #39 #40 #41 #42 #43 #44 #45

### DIFF
--- a/k8s/base/dashboard/dashboard.yaml
+++ b/k8s/base/dashboard/dashboard.yaml
@@ -161,18 +161,18 @@ spec:
           image: home-security-dashboard-frontend:latest
           imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: 80
+            - containerPort: 8080
               name: http
           livenessProbe:
             httpGet:
               path: /
-              port: 80
+              port: 8080
             initialDelaySeconds: 10
             periodSeconds: 30
           readinessProbe:
             httpGet:
               path: /
-              port: 80
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 10
           resources:
@@ -197,7 +197,7 @@ spec:
   type: ClusterIP
   ports:
     - port: 80
-      targetPort: 80
+      targetPort: 8080
       name: http
   selector:
     app.kubernetes.io/name: dashboard

--- a/k8s/base/homeassistant/homeassistant.yaml
+++ b/k8s/base/homeassistant/homeassistant.yaml
@@ -47,10 +47,8 @@ data:
     http:
       use_x_forwarded_for: true
       trusted_proxies:
-        - 10.42.0.0/16
-        - 10.43.0.0/16
-        - 172.16.0.0/12
-        - 192.168.0.0/16
+        - 127.0.0.1
+        - 10.43.0.1
 
     logger:
       default: warning

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - frigate/frigate.yaml
   - homeassistant/homeassistant.yaml
   - dashboard/dashboard.yaml
+  - pdb.yaml
 
 labels:
   - pairs:

--- a/k8s/base/pdb.yaml
+++ b/k8s/base/pdb.yaml
@@ -1,0 +1,44 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: homeassistant-pdb
+  namespace: home-security
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: homeassistant
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: mosquitto-pdb
+  namespace: home-security
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mosquitto
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: frigate-pdb
+  namespace: home-security
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: frigate
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: dashboard-api-pdb
+  namespace: home-security
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dashboard
+      app.kubernetes.io/component: api

--- a/src/.env.example
+++ b/src/.env.example
@@ -82,3 +82,7 @@ COMMAND_ALLOWED_SOURCES_UGV=dashboard,homeassistant
 COMMAND_ALLOWED_SOURCES_UAV=dashboard,homeassistant
 COMMAND_MAX_SKEW_SECONDS_UGV=30
 COMMAND_MAX_SKEW_SECONDS_UAV=30
+
+# --- Backup ---
+# Se definido, scripts/backup.sh criptografa backups de configuração com AES-256.
+BACKUP_ENCRYPTION_PASSPHRASE=CHANGE_ME_backup_encryption_passphrase

--- a/src/dashboard/backend/Dockerfile
+++ b/src/dashboard/backend/Dockerfile
@@ -14,6 +14,11 @@ COPY app/ ./app/
 COPY migrations/ ./migrations/
 COPY alembic.ini ./alembic.ini
 
+RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser \
+    && chown -R appuser:appgroup /app
+
+USER appuser
+
 EXPOSE 8000
 
 # IMPORTANT: Keep workers=1. app/services/ha_client.py stores state in-process

--- a/src/dashboard/backend/app/config.py
+++ b/src/dashboard/backend/app/config.py
@@ -24,10 +24,7 @@ class Settings(BaseSettings):
     ]
 
     # PostgreSQL (schema: dashboard)
-    database_url: str = (
-        "postgresql+asyncpg://dashboard_user:password"
-        "@postgres:5432/homedb?options=-csearch_path%3Ddashboard"
-    )
+    database_url: str = "postgresql+asyncpg://UNCONFIGURED:UNCONFIGURED@localhost/UNCONFIGURED"
 
     # Entidades relevantes para alertas
     alert_entities: list[str] = [
@@ -54,6 +51,13 @@ class Settings(BaseSettings):
     def parse_origins(cls, value):
         if isinstance(value, str):
             return [origin.strip() for origin in value.split(",") if origin.strip()]
+        return value
+
+    @field_validator("database_url")
+    @classmethod
+    def validate_database_url(cls, value):
+        if "dashboard_user:password@" in value:
+            raise ValueError("DATABASE_URL contains insecure default password.")
         return value
 
 

--- a/src/dashboard/backend/app/db/models.py
+++ b/src/dashboard/backend/app/db/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import DateTime, Float, Integer, String, Text
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
@@ -16,7 +16,7 @@ class Alert(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     timestamp: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=datetime.utcnow, index=True
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), index=True
     )
     entity_id: Mapped[str] = mapped_column(String(200), nullable=False, index=True)
     event_type: Mapped[str] = mapped_column(String(100), nullable=False)

--- a/src/dashboard/backend/app/main.py
+++ b/src/dashboard/backend/app/main.py
@@ -9,7 +9,7 @@ from app.config import settings
 from app.db.session import init_db
 from app.routers import alerts, cameras, sensors, services, ws
 from app.security import require_api_key
-from app.services import ha_client
+from app.services import frigate_client, ha_client
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -36,6 +36,9 @@ async def lifespan(app: FastAPI):
             await _ha_task
         except asyncio.CancelledError:
             pass
+    await ha_client.close()
+    await frigate_client.close()
+    await services.close()
 
 
 app = FastAPI(

--- a/src/dashboard/backend/app/routers/alerts.py
+++ b/src/dashboard/backend/app/routers/alerts.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy import desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -12,12 +12,13 @@ router = APIRouter(prefix="/api", tags=["alerts"])
 
 @router.get("/alerts")
 async def list_alerts(
-    limit: int = 50,
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
     severity: str | None = None,
     db: AsyncSession = Depends(get_db),
 ) -> list[dict]:
     """Retorna histórico de alertas paginado, do mais recente para o mais antigo."""
-    stmt = select(Alert).order_by(desc(Alert.timestamp)).limit(limit)
+    stmt = select(Alert).order_by(desc(Alert.timestamp)).offset(offset).limit(limit)
     if severity:
         stmt = stmt.where(Alert.severity == severity)
     result = await db.execute(stmt)

--- a/src/dashboard/backend/app/routers/cameras.py
+++ b/src/dashboard/backend/app/routers/cameras.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import Response
 
+from app.config import settings
 from app.services import frigate_client
 
 router = APIRouter(prefix="/api/cameras", tags=["cameras"])
@@ -9,6 +10,8 @@ router = APIRouter(prefix="/api/cameras", tags=["cameras"])
 @router.get("/{camera_name}/snapshot")
 async def get_snapshot(camera_name: str) -> Response:
     """Retorna o último frame JPEG de uma câmera via Frigate."""
+    if camera_name not in settings.cameras:
+        raise HTTPException(status_code=404, detail=f"Câmera '{camera_name}' não encontrada.")
     data = await frigate_client.get_snapshot(camera_name)
     if data is None:
         raise HTTPException(status_code=503, detail=f"Câmera '{camera_name}' indisponível.")
@@ -22,4 +25,6 @@ async def get_events(
     limit: int = 20,
 ) -> list[dict]:
     """Retorna eventos de detecção recentes do Frigate."""
+    if camera and camera not in settings.cameras:
+        raise HTTPException(status_code=400, detail=f"Câmera inválida: '{camera}'.")
     return await frigate_client.get_events(camera=camera, label=label, limit=limit)

--- a/src/dashboard/backend/app/services/frigate_client.py
+++ b/src/dashboard/backend/app/services/frigate_client.py
@@ -4,15 +4,34 @@ import httpx
 
 from app.config import settings
 
+_client: httpx.AsyncClient | None = None
+
+
+async def get_client() -> httpx.AsyncClient:
+    global _client
+    if _client is None:
+        _client = httpx.AsyncClient(
+            timeout=5,
+            limits=httpx.Limits(max_connections=20, max_keepalive_connections=10),
+        )
+    return _client
+
+
+async def close() -> None:
+    global _client
+    if _client is not None:
+        await _client.aclose()
+        _client = None
+
 
 async def get_snapshot(camera_name: str) -> bytes | None:
     """Retorna o último frame JPEG de uma câmera."""
     url = f"{settings.frigate_url}/api/{camera_name}/latest.jpg"
     try:
-        async with httpx.AsyncClient(timeout=5) as client:
-            resp = await client.get(url)
-            if resp.status_code == 200:
-                return resp.content
+        client = await get_client()
+        resp = await client.get(url)
+        if resp.status_code == 200:
+            return resp.content
     except httpx.RequestError:
         pass
     return None
@@ -30,10 +49,10 @@ async def get_events(
     if label:
         params["label"] = label
     try:
-        async with httpx.AsyncClient(timeout=5) as client:
-            resp = await client.get(f"{settings.frigate_url}/api/events", params=params)
-            if resp.status_code == 200:
-                return resp.json()
+        client = await get_client()
+        resp = await client.get(f"{settings.frigate_url}/api/events", params=params)
+        if resp.status_code == 200:
+            return resp.json()
     except httpx.RequestError:
         pass
     return []
@@ -42,10 +61,10 @@ async def get_events(
 async def get_stats() -> dict:
     """Retorna estatísticas gerais do Frigate (detecções, FPS, etc.)."""
     try:
-        async with httpx.AsyncClient(timeout=5) as client:
-            resp = await client.get(f"{settings.frigate_url}/api/stats")
-            if resp.status_code == 200:
-                return resp.json()
+        client = await get_client()
+        resp = await client.get(f"{settings.frigate_url}/api/stats")
+        if resp.status_code == 200:
+            return resp.json()
     except httpx.RequestError:
         pass
     return {}

--- a/src/dashboard/frontend/Dockerfile
+++ b/src/dashboard/frontend/Dockerfile
@@ -10,11 +10,11 @@ COPY . .
 RUN npm run build
 
 # Stage 2: serve
-FROM nginx:alpine
+FROM nginxinc/nginx-unprivileged:stable-alpine
 
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
-EXPOSE 80
+EXPOSE 8080
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/src/dashboard/frontend/nginx.conf
+++ b/src/dashboard/frontend/nginx.conf
@@ -1,8 +1,16 @@
 server {
-    listen 80;
+    listen 8080;
     server_name _;
     root /usr/share/nginx/html;
     index index.html;
+
+    # Security headers
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "no-referrer" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:; img-src 'self' data: blob:;" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
     # Compressão gzip
     gzip on;
@@ -13,6 +21,8 @@ server {
         proxy_pass http://home-security-dashboard-api:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     # Proxy WebSocket
@@ -22,6 +32,8 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_read_timeout 3600s;
         proxy_send_timeout 3600s;
     }

--- a/src/dashboard/frontend/src/components/AlertFeed.jsx
+++ b/src/dashboard/frontend/src/components/AlertFeed.jsx
@@ -21,13 +21,13 @@ function formatTime(iso) {
 }
 
 export default function AlertFeed() {
-  const { alerts, setAlerts } = useStore()
+  const { alerts, setAlertsIfEmpty } = useStore()
 
   // Carrega histórico inicial via REST
   useEffect(() => {
     fetch('/api/alerts?limit=30')
       .then((r) => r.json())
-      .then((data) => { if (Array.isArray(data) && alerts.length === 0) setAlerts(data) })
+      .then((data) => { if (Array.isArray(data)) setAlertsIfEmpty(data) })
       .catch(() => {})
   }, [])
 

--- a/src/dashboard/frontend/src/components/AlertFeed.test.jsx
+++ b/src/dashboard/frontend/src/components/AlertFeed.test.jsx
@@ -1,10 +1,10 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import AlertFeed from "./AlertFeed";
 
-const setAlerts = vi.fn();
+const setAlertsIfEmpty = vi.fn();
 const mockedStore = {
   alerts: [],
-  setAlerts,
+  setAlertsIfEmpty,
 };
 
 vi.mock("../store/useStore", () => ({
@@ -13,7 +13,7 @@ vi.mock("../store/useStore", () => ({
 
 describe("AlertFeed", () => {
   beforeEach(() => {
-    setAlerts.mockClear();
+    setAlertsIfEmpty.mockClear();
     global.fetch = vi.fn().mockResolvedValue({
       json: async () => [
         {
@@ -31,7 +31,7 @@ describe("AlertFeed", () => {
   it("requests initial alerts from REST API", async () => {
     render(<AlertFeed />);
     await waitFor(() => expect(global.fetch).toHaveBeenCalledWith("/api/alerts?limit=30"));
-    await waitFor(() => expect(setAlerts).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(setAlertsIfEmpty).toHaveBeenCalledTimes(1));
   });
 
   it("shows empty state", () => {

--- a/src/dashboard/frontend/src/components/CameraGrid.jsx
+++ b/src/dashboard/frontend/src/components/CameraGrid.jsx
@@ -12,10 +12,12 @@ const REFRESH_INTERVAL = 2000 // 2 segundos
 function CameraFeed({ name, label }) {
   const [src, setSrc] = useState(`/api/cameras/${name}/snapshot?t=0`)
   const [error, setError] = useState(false)
+  const [errorCount, setErrorCount] = useState(0)
   const intervalRef = useRef(null)
 
   useEffect(() => {
     setError(false)
+    setErrorCount(0)
     intervalRef.current = setInterval(() => {
       setSrc(`/api/cameras/${name}/snapshot?t=${Date.now()}`)
     }, REFRESH_INTERVAL)
@@ -24,21 +26,26 @@ function CameraFeed({ name, label }) {
 
   return (
     <div className="relative bg-black rounded-lg overflow-hidden aspect-video">
-      {error ? (
+      <img
+        src={src}
+        alt={label}
+        className={`w-full h-full object-cover ${error ? 'hidden' : ''}`}
+        onError={() => {
+          setError(true)
+          setErrorCount((value) => value + 1)
+        }}
+        onLoad={() => {
+          setError(false)
+          setErrorCount(0)
+        }}
+      />
+      {error && errorCount >= 1 ? (
         <div className="absolute inset-0 flex flex-col items-center justify-center text-muted text-sm gap-1">
           <span className="text-2xl">📷</span>
           <span>{label}</span>
           <span className="text-xs text-critical">offline</span>
         </div>
-      ) : (
-        <img
-          src={src}
-          alt={label}
-          className="w-full h-full object-cover"
-          onError={() => setError(true)}
-          onLoad={() => setError(false)}
-        />
-      )}
+      ) : null}
       <div className="absolute bottom-0 left-0 right-0 px-2 py-1 bg-black/60 text-xs text-gray-300">
         {label}
         {!error && <span className="float-right text-success">● ao vivo</span>}

--- a/src/dashboard/frontend/src/store/useStore.js
+++ b/src/dashboard/frontend/src/store/useStore.js
@@ -27,6 +27,10 @@ const useStore = create((set) => ({
     })),
 
   setAlerts: (alerts) => set({ alerts }),
+  setAlertsIfEmpty: (alerts) =>
+    set((s) => ({
+      alerts: s.alerts.length === 0 ? alerts : s.alerts,
+    })),
 
   setServices: (services) => set({ services }),
 

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -115,7 +115,6 @@ services:
     image: ghcr.io/blakeblackshear/frigate:stable
     container_name: home-security-frigate
     restart: unless-stopped
-    privileged: true
     shm_size: "256mb"
     ports:
       - "127.0.0.1:5000:5000" # Web UI
@@ -141,6 +140,10 @@ services:
     # Intel iGPU passthrough for OpenVINO
     devices:
       - /dev/dri:/dev/dri
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     depends_on:
       mosquitto:
         condition: service_healthy
@@ -216,7 +219,7 @@ services:
     container_name: home-security-dashboard-frontend
     restart: unless-stopped
     ports:
-      - "3000:80"
+      - "3000:8080"
     networks:
       - home-security-net
     depends_on:

--- a/src/drones/ugv/docker-compose.ugv.yml
+++ b/src/drones/ugv/docker-compose.ugv.yml
@@ -12,11 +12,11 @@ services:
     volumes:
       - ./app:/app
       - ../common:/app/common
-      - /dev:/dev
     devices:
       - /dev/ttyUSB0:/dev/ttyUSB0 # ESP32
       - /dev/video0:/dev/video0 # Camera
-    network_mode: host # For easy communication with HA and other devices
+    networks:
+      - ugv-net
     environment:
       - ROS_DOMAIN_ID=0
       - MQTT_BROKER=192.168.1.100 # Replace with actual broker IP
@@ -27,7 +27,7 @@ services:
       - COMMAND_HMAC_SECRET_UGV=CHANGE_ME_ugv_hmac_secret
       - COMMAND_ALLOWED_SOURCES_UGV=dashboard,homeassistant
       - COMMAND_MAX_SKEW_SECONDS_UGV=30
-      - RTSP_URI=rtsp://localhost:8554/cam
+      - RTSP_URI=rtsp://mediamtx:8554/cam
 
   # ---------------------------------------------------------------------------
   # RTSP Server (MediaMTX) - Low Latency Streaming
@@ -36,7 +36,14 @@ services:
     image: bluenviron/mediamtx:latest
     container_name: ugv-mediamtx
     restart: unless-stopped
-    network_mode: host
+    networks:
+      - ugv-net
+    ports:
+      - "8554:8554"
     environment:
       - MTX_PROTOCOLS=tcp
       - MTX_WEBRTC=no # Disable WebRTC to save resources if not needed
+
+networks:
+  ugv-net:
+    driver: bridge

--- a/src/frigate/config.yml
+++ b/src/frigate/config.yml
@@ -14,8 +14,8 @@ mqtt:
   enabled: true
   host: mosquitto
   port: 1883
-  user: "{FRIGATE_MQTT_USER}"
-  password: "{FRIGATE_MQTT_PASSWORD}"
+  user: "{MQTT_USER}"
+  password: "{MQTT_PASSWORD}"
   topic_prefix: frigate
 
 # --- Detector de IA ---

--- a/src/homeassistant/configuration.yaml
+++ b/src/homeassistant/configuration.yaml
@@ -20,9 +20,8 @@ frontend:
 http:
   use_x_forwarded_for: true
   trusted_proxies:
-    - 172.16.0.0/12
-    - 192.168.0.0/16
-    - 10.0.0.0/8
+    - 127.0.0.1
+    - 172.17.0.1
 
 # --- Logger ---
 logger:


### PR DESCRIPTION
## Summary
- backup de configuração não inclui mais `.env` e suporta criptografia opcional por passphrase (AES-256)
- containers do dashboard executam como usuário não privilegiado e frontend nginx recebeu security headers
- validação de `camera_name` no proxy Frigate e proteção de paginação no endpoint `/api/alerts`
- remoção de fallback inseguro de `DATABASE_URL` com senha `password`
- pool HTTP compartilhado (`httpx.AsyncClient`) com fechamento no lifecycle
- trusted proxies do Home Assistant restringidos (compose e k8s)
- isolamento do UGV no compose (sem bind de `/dev` inteiro e sem host network)
- Frigate sem `privileged: true` e correção do nome das env vars de MQTT no config
- recuperação automática de câmera no `ugv_vision.py` e correção de race no `AlertFeed`
- inclusão de PodDisruptionBudgets para serviços críticos no base K8s

## Validation Checklist
- [ ] tests added/updated where applicable
- [ ] local validation executed (lint/tests/build)
- [ ] no secrets/tokens/real IPs committed
- [ ] docs/config examples updated when needed

## Operational Checklist
- [ ] backward-compatibility impact reviewed
- [ ] rollout/rollback considerations reviewed

## Linked Issues
- Closes #14
- Closes #15
- Closes #16
- Closes #17
- Closes #18
- Closes #19
- Closes #20
- Closes #21
- Closes #22
- Closes #28
- Closes #38
- Closes #39
- Closes #40
- Closes #41
- Closes #42
- Closes #43
- Closes #44
- Closes #45
