### PR TITLE
fix: resolve remaining low issues #23 #24 #25 #26 #27 #29 #46 #47 #48 #49

### DIFF
--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -65,16 +65,22 @@ jobs:
       - name: Snyk IaC test and report
         run: snyk iac test --report # || true
 
-        # Build the docker image for testing
-      - name: Build a Docker image
-        run: docker build -t your/image-to-test .
-        # Runs Snyk Container (Container and SCA) analysis and uploads result to Snyk.
-      - name: Snyk Container monitor
-        run: snyk container monitor your/image-to-test --file=Dockerfile
+        # Build and scan Dashboard API image
+      - name: Build Dashboard API image
+        run: docker build -t home-security/dashboard-api:test ./src/dashboard/backend
+
+      - name: Snyk Container monitor - Dashboard API
+        run: snyk container monitor home-security/dashboard-api:test --file=src/dashboard/backend/Dockerfile
+
+        # Build and scan Dashboard Frontend image
+      - name: Build Dashboard Frontend image
+        run: docker build -t home-security/dashboard-frontend:test ./src/dashboard/frontend
+
+      - name: Snyk Container monitor - Dashboard Frontend
+        run: snyk container monitor home-security/dashboard-frontend:test --file=src/dashboard/frontend/Dockerfile
 
         # Push the Snyk Code results into GitHub Code Scanning tab
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk-code.sarif
-

--- a/k8s/base/dashboard/dashboard.yaml
+++ b/k8s/base/dashboard/dashboard.yaml
@@ -16,7 +16,7 @@ metadata:
 type: Opaque
 stringData:
   ha-token: "CHANGE_ME_ha_long_lived_token"
-  ha-url: "http://192.168.10.10:8123"
+  ha-url: "http://HOME_ASSISTANT_HOST_IP:8123"
   database-url: "postgresql+asyncpg://dashboard_user:CHANGE_ME_dashboard_password@postgres:5432/homedb?options=-csearch_path%3Ddashboard"
 
 ---

--- a/k8s/docs/K3S_SETUP.md
+++ b/k8s/docs/K3S_SETUP.md
@@ -82,6 +82,15 @@ chmod +x scripts/generate-k8s-secrets.sh
 kubectl apply -f k8s/generated/secrets/
 ```
 
+Para o Ingress TLS em produção, crie também o secret de certificado:
+
+```bash
+kubectl create secret tls home-security-tls \
+  -n home-security \
+  --cert=/caminho/para/fullchain.pem \
+  --key=/caminho/para/privkey.pem
+```
+
 Alternativa manual:
 
 ```bash

--- a/k8s/overlays/production/ingress.yaml
+++ b/k8s/overlays/production/ingress.yaml
@@ -23,6 +23,13 @@ metadata:
     traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
   ingressClassName: traefik
+  tls:
+    - secretName: home-security-tls
+      hosts:
+        - security.home.local
+        - frigate.home.local
+        - zigbee.home.local
+        - dashboard.home.local
   rules:
     # --- Home Assistant ---
     - host: security.home.local

--- a/src/.env.example
+++ b/src/.env.example
@@ -24,16 +24,16 @@ ZIGBEE_DEVICE=/dev/ttyUSB0
 # --- Frigate NVR ---
 # Camera RTSP URLs (update with your camera IPs and credentials)
 # Format: rtsp://user:password@ip:554/stream
-FRIGATE_CAM_ENTRADA_URL=rtsp://admin:password@192.168.30.10:554/h264Preview_01_main
-FRIGATE_CAM_FUNDOS_URL=rtsp://admin:password@192.168.30.11:554/h264Preview_01_main
-FRIGATE_CAM_LATERAL_URL=rtsp://admin:password@192.168.30.12:554/h264Preview_01_main
-FRIGATE_CAM_GARAGEM_URL=rtsp://admin:password@192.168.30.13:554/h264Preview_01_main
+FRIGATE_CAM_ENTRADA_URL=rtsp://admin:password@CAMERA_ENTRADA_IP:554/h264Preview_01_main
+FRIGATE_CAM_FUNDOS_URL=rtsp://admin:password@CAMERA_FUNDOS_IP:554/h264Preview_01_main
+FRIGATE_CAM_LATERAL_URL=rtsp://admin:password@CAMERA_LATERAL_IP:554/h264Preview_01_main
+FRIGATE_CAM_GARAGEM_URL=rtsp://admin:password@CAMERA_GARAGEM_IP:554/h264Preview_01_main
 
 # Substream URLs (lower resolution for detection - saves CPU)
-FRIGATE_CAM_ENTRADA_SUB_URL=rtsp://admin:password@192.168.30.10:554/h264Preview_01_sub
-FRIGATE_CAM_FUNDOS_SUB_URL=rtsp://admin:password@192.168.30.11:554/h264Preview_01_sub
-FRIGATE_CAM_LATERAL_SUB_URL=rtsp://admin:password@192.168.30.12:554/h264Preview_01_sub
-FRIGATE_CAM_GARAGEM_SUB_URL=rtsp://admin:password@192.168.30.13:554/h264Preview_01_sub
+FRIGATE_CAM_ENTRADA_SUB_URL=rtsp://admin:password@CAMERA_ENTRADA_IP:554/h264Preview_01_sub
+FRIGATE_CAM_FUNDOS_SUB_URL=rtsp://admin:password@CAMERA_FUNDOS_IP:554/h264Preview_01_sub
+FRIGATE_CAM_LATERAL_SUB_URL=rtsp://admin:password@CAMERA_LATERAL_IP:554/h264Preview_01_sub
+FRIGATE_CAM_GARAGEM_SUB_URL=rtsp://admin:password@CAMERA_GARAGEM_IP:554/h264Preview_01_sub
 
 # --- Storage ---
 # Path for Frigate recordings (use a dedicated HDD/SSD mount)
@@ -61,7 +61,7 @@ POSTGRES_METRICS_PASSWORD=CHANGE_ME_metrics_password
 
 # --- Dashboard Operacional (Issue #2) ---
 # IP do host onde o Home Assistant está rodando (network_mode: host)
-HA_HOST=192.168.10.10
+HA_HOST=HOME_ASSISTANT_HOST_IP
 # Long-lived access token gerado em HA: Perfil → Tokens de acesso longa duração
 HA_TOKEN=CHANGE_ME_ha_long_lived_token
 # API key obrigatória para autenticar chamadas HTTP e WebSocket na Dashboard API

--- a/src/dashboard/backend/app/routers/services.py
+++ b/src/dashboard/backend/app/routers/services.py
@@ -37,7 +37,7 @@ async def _check_http(url: str) -> str:
         resp = await client.get(
             url,
             headers={"Authorization": f"Bearer {settings.ha_token}"}
-            if "8123" in url
+            if url.startswith(settings.ha_url)
             else {},
         )
         return "online" if resp.status_code < 500 else "degraded"

--- a/src/dashboard/frontend/.dockerignore
+++ b/src/dashboard/frontend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.git/
+*.md
+.env*

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "mosquitto_sub -h localhost -p 1883 -t '$$SYS/broker/uptime' -C 1 -u ${MQTT_USER} -P ${MQTT_PASSWORD} || exit 1",
+          "nc -z localhost 1883 || exit 1",
         ]
       interval: 30s
       timeout: 10s
@@ -89,7 +89,7 @@ services:
   # Requer coordenador USB (Sonoff ZBDongle-P ou compatível).
   # ---------------------------------------------------------------------------
   zigbee2mqtt:
-    image: koenkk/zigbee2mqtt:latest
+    image: koenkk/zigbee2mqtt:1.42.0
     container_name: home-security-zigbee2mqtt
     restart: unless-stopped
     ports:
@@ -112,7 +112,7 @@ services:
   # Usa Intel OpenVINO (iGPU do N100) para aceleração.
   # ---------------------------------------------------------------------------
   frigate:
-    image: ghcr.io/blakeblackshear/frigate:stable
+    image: ghcr.io/blakeblackshear/frigate:0.14.1
     container_name: home-security-frigate
     restart: unless-stopped
     shm_size: "256mb"
@@ -155,7 +155,7 @@ services:
   # Plataforma central de automação, dashboard e sistema de alarme (Alarmo).
   # ---------------------------------------------------------------------------
   homeassistant:
-    image: ghcr.io/home-assistant/home-assistant:stable
+    image: ghcr.io/home-assistant/home-assistant:2024.12.5
     container_name: home-security-homeassistant
     restart: unless-stopped
     network_mode: host

--- a/src/drones/ugv/app/ugv_control.py
+++ b/src/drones/ugv/app/ugv_control.py
@@ -122,7 +122,18 @@ def on_message(client, userdata, msg):
             send_motor_cmd(left, right)
             
         elif command == 'patrol':
-            print("Starting Patrol Sequence...")
+            print("Patrol command received but feature is not implemented yet.")
+            client.publish(
+                MQTT_TOPIC_STATUS,
+                json.dumps(
+                    {
+                        "state": "warning",
+                        "command": "patrol",
+                        "status": "not_implemented",
+                        "reason": "Patrol sequence pending implementation",
+                    }
+                ),
+            )
             
     except Exception as e:
         print(f"Error parsing command: {e}")
@@ -154,6 +165,7 @@ def main():
     
     try:
         client.connect(MQTT_BROKER, MQTT_PORT, 60)
+        health.update_heartbeat()
         client.loop_start()
     except Exception as e:
         print(f"Error connecting to MQTT: {e}")

--- a/src/drones/ugv/docker-compose.ugv.yml
+++ b/src/drones/ugv/docker-compose.ugv.yml
@@ -5,7 +5,7 @@ services:
   # UGV Brain (ROS 2 Humble)
   # ---------------------------------------------------------------------------
   ugv-brain:
-    image: osrf/ros:humble-desktop
+    image: osrf/ros:humble-desktop-jammy
     container_name: ugv-brain
     restart: unless-stopped
     command: python3 /app/ugv_control.py
@@ -33,7 +33,7 @@ services:
   # RTSP Server (MediaMTX) - Low Latency Streaming
   # ---------------------------------------------------------------------------
   mediamtx:
-    image: bluenviron/mediamtx:latest
+    image: bluenviron/mediamtx:1.11.3
     container_name: ugv-mediamtx
     restart: unless-stopped
     networks:

--- a/src/homeassistant/configuration.yaml
+++ b/src/homeassistant/configuration.yaml
@@ -33,7 +33,7 @@ logger:
 
 # --- Recorder (history database) ---
 recorder:
-  db_url: sqlite:////config/home-assistant_v2.db
+  db_url: !env_var POSTGRES_HA_URL
   purge_keep_days: 30
   commit_interval: 5
   exclude:


### PR DESCRIPTION
## Summary
- pin de imagens antes mutáveis (`latest/stable`) para versões explícitas em compose
- ingress de produção com seção `spec.tls` e `secretName` + documentação para criar secret TLS
- Home Assistant recorder migrado para `POSTGRES_HA_URL` (SQLite removido)
- healthcheck do Mosquitto sem credenciais em linha de comando
- workflow Snyk corrigido para build/scan de imagens reais do projeto
- sanitização de IPs internos em `.env.example` e `k8s/base/dashboard/dashboard.yaml`
- correção da lógica de auth header em `services.py` (sem dependência de porta 8123)
- comando `patrol` no UGV agora retorna status explícito `not_implemented`
- reset de heartbeat após conexão MQTT bem-sucedida no UGV
- inclusão de `.dockerignore` no frontend para evitar contaminação de build

## Validation Checklist
- [ ] tests added/updated where applicable
- [ ] local validation executed (lint/tests/build)
- [ ] no secrets/tokens/real IPs committed
- [ ] docs/config examples updated when needed

## Operational Checklist
- [ ] backward-compatibility impact reviewed
- [ ] rollout/rollback considerations reviewed

## Linked Issues
- Closes #23
- Closes #24
- Closes #25
- Closes #26
- Closes #27
- Closes #29
- Closes #46
- Closes #47
- Closes #48
- Closes #49
