### PR TITLE
fix: alinhar autenticação dashboard via proxy nginx

### DIFF
--- a/src/dashboard/frontend/Dockerfile
+++ b/src/dashboard/frontend/Dockerfile
@@ -13,7 +13,7 @@ RUN npm run build
 FROM nginxinc/nginx-unprivileged:stable-alpine
 
 COPY --from=builder /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf.template /etc/nginx/templates/default.conf.template
 
 EXPOSE 8080
 

--- a/src/dashboard/frontend/nginx.conf.template
+++ b/src/dashboard/frontend/nginx.conf.template
@@ -23,6 +23,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-API-Key "${DASHBOARD_API_KEY}";
     }
 
     # Proxy WebSocket
@@ -34,6 +35,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-API-Key "${DASHBOARD_API_KEY}";
         proxy_read_timeout 3600s;
         proxy_send_timeout 3600s;
     }

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -218,6 +218,9 @@ services:
     image: home-security-dashboard-frontend:latest
     container_name: home-security-dashboard-frontend
     restart: unless-stopped
+    environment:
+      - DASHBOARD_API_KEY=${DASHBOARD_API_KEY}
+      - NGINX_ENVSUBST_FILTER=^DASHBOARD_API_KEY$
     ports:
       - "3000:8080"
     networks:


### PR DESCRIPTION
## Resumo
- injeta X-API-Key no proxy Nginx para chamadas /api/*
- injeta X-API-Key também no proxy WebSocket /ws
- migra config para template com envsubst e adiciona variáveis no compose

## Observações
- Não foi possível executar testes frontend neste ambiente por erro de permissão (EPERM) ao executar binário do esbuild.
- docker não está disponível no ambiente local para validar docker compose config.

Fixes #56
