### PR TITLE
feat: observabilidade de drops no WebSocket

### DIFF
--- a/src/dashboard/backend/app/routers/services.py
+++ b/src/dashboard/backend/app/routers/services.py
@@ -56,3 +56,9 @@ async def services_status() -> dict:
     results["ha_websocket"] = "online" if ha_client.get_all_states() else "connecting"
 
     return {"services": results}
+
+
+@router.get("/ws-metrics")
+async def ws_metrics() -> dict:
+    """Retorna métricas operacionais do fan-out WebSocket."""
+    return {"ws_metrics": ha_client.get_ws_metrics()}

--- a/src/dashboard/backend/app/routers/ws.py
+++ b/src/dashboard/backend/app/routers/ws.py
@@ -26,10 +26,11 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
         try:
             queue.put_nowait(payload)
         except asyncio.QueueFull:
-            pass  # descarta mensagem se fila cheia (cliente lento)
+            ha_client.record_ws_drop()
+            logger.warning("Fila de WebSocket cheia; descartando mensagem para cliente lento.")
 
     ha_client.subscribe(enqueue)
-    logger.info("Cliente WS conectado. Total: %d", len(ha_client._subscribers))
+    logger.info("Cliente WS conectado. Total: %d", ha_client.get_ws_metrics()["connected_clients"])
 
     # Envia snapshot completo dos estados atuais ao conectar
     try:

--- a/tests/backend/test_dashboard_api.py
+++ b/tests/backend/test_dashboard_api.py
@@ -135,6 +135,10 @@ def test_services_route_with_api_key(monkeypatch):
     assert resp.status_code == 200
     assert resp.json()["services"]["ha_websocket"] == "online"
 
+    metrics = client.get("/api/services/ws-metrics", headers={"X-API-Key": "test-api-key"})
+    assert metrics.status_code == 200
+    assert "ws_metrics" in metrics.json()
+
 
 def test_ws_requires_api_key():
     app = _build_test_app()


### PR DESCRIPTION
## Resumo
- adiciona métricas de observabilidade do fan-out WebSocket no `ha_client`
- contabiliza drops de fila cheia e falhas de entrega
- expõe endpoint autenticado `/api/services/ws-metrics`
- ajusta testes backend para cobrir novo endpoint

## Validação
- python3 -m compileall src/dashboard/backend/app tests/backend

Fixes #61
