### PR TITLE
feat: retenção e otimização de histórico de alertas

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,20 @@ O projeto inclui uma camada reativa avançada com **frota modular de drones aut�
 
 ---
 
+## Manutenção de Alertas
+
+O histórico de alertas do dashboard possui retenção configurável (`ALERT_RETENTION_DAYS`, padrão 90 dias).
+
+Para executar limpeza manual de registros antigos:
+
+```bash
+python3 scripts/cleanup_alerts.py
+```
+
+Você pode agendar esse comando via `cron` no servidor para manutenção contínua.
+
+---
+
 ## Contribuição
 
 Contribuições são bem-vindas! Por favor, leia o [CONTRIBUTING.md](CONTRIBUTING.md) (em breve) para detalhes sobre nosso código de conduta e processo de envio de pull requests.

--- a/scripts/cleanup_alerts.py
+++ b/scripts/cleanup_alerts.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Cleanup old dashboard alerts based on retention policy."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+# Ensure backend modules are importable when script runs from repository root.
+BACKEND_DIR = Path(__file__).resolve().parents[1] / "src" / "dashboard" / "backend"
+sys.path.insert(0, str(BACKEND_DIR))
+
+from app.config import settings
+from app.db.models import Alert
+
+
+def _database_url() -> str:
+    return os.getenv("DATABASE_URL", settings.database_url)
+
+
+def _retention_days() -> int:
+    raw = os.getenv("ALERT_RETENTION_DAYS", str(settings.alert_retention_days))
+    return max(int(raw), 1)
+
+
+async def _run() -> None:
+    retention_days = _retention_days()
+    cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
+    engine = create_async_engine(_database_url(), echo=False, pool_pre_ping=True)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with session_factory() as session:
+        result = await session.execute(
+            delete(Alert).where(Alert.timestamp < cutoff)
+        )
+        await session.commit()
+        deleted = int(result.rowcount or 0)
+
+    await engine.dispose()
+    print(
+        f"[cleanup_alerts] retention_days={retention_days} cutoff={cutoff.isoformat()} deleted={deleted}"
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(_run())

--- a/src/dashboard/backend/app/config.py
+++ b/src/dashboard/backend/app/config.py
@@ -37,6 +37,7 @@ class Settings(BaseSettings):
         "binary_sensor.ugv_online",
         "binary_sensor.uav_armed",
     ]
+    alert_retention_days: int = 90
 
     # Câmeras disponíveis
     cameras: list[str] = [

--- a/src/dashboard/backend/app/db/models.py
+++ b/src/dashboard/backend/app/db/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 
-from sqlalchemy import DateTime, Float, Integer, String, Text
+from sqlalchemy import DateTime, Float, Index, Integer, String, Text
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
@@ -12,7 +12,10 @@ class Alert(Base):
     """Histórico de alertas e eventos do sistema de segurança."""
 
     __tablename__ = "alerts"
-    __table_args__ = {"schema": "dashboard"}
+    __table_args__ = (
+        Index("ix_dashboard_alerts_severity_timestamp", "severity", "timestamp"),
+        {"schema": "dashboard"},
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     timestamp: Mapped[datetime] = mapped_column(

--- a/src/dashboard/backend/migrations/versions/20260219_0002_alerts_retention_index.py
+++ b/src/dashboard/backend/migrations/versions/20260219_0002_alerts_retention_index.py
@@ -1,0 +1,34 @@
+"""add alerts severity-timestamp index
+
+Revision ID: 20260219_0002
+Revises: 20260219_0001
+Create Date: 2026-02-19 00:20:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260219_0002"
+down_revision: Union[str, None] = "20260219_0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_dashboard_alerts_severity_timestamp",
+        "alerts",
+        ["severity", "timestamp"],
+        unique=False,
+        schema="dashboard",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_dashboard_alerts_severity_timestamp",
+        table_name="alerts",
+        schema="dashboard",
+    )


### PR DESCRIPTION
## Resumo
- adiciona política de retenção de alertas (`alert_retention_days`, padrão 90)
- adiciona índice composto `severity,timestamp` para consultas do histórico
- cria migration Alembic para novo índice
- adiciona script `scripts/cleanup_alerts.py` para limpeza agendada de alertas antigos
- documenta manutenção no README

## Validação
- python3 -m compileall src/dashboard/backend/app src/dashboard/backend/migrations scripts/cleanup_alerts.py

Fixes #62
