### PR TITLE
docs: alinhar README e validar links markdown no CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -81,6 +81,15 @@ jobs:
       - name: Lint scripts
         run: shellcheck scripts/*.sh
 
+  docs-links:
+    name: Validate Markdown Links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate local markdown links
+        run: bash scripts/validate-doc-links.sh
+
   frontend-quality:
     name: Frontend Lint and Tests
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -85,18 +85,23 @@ Para instalação definitiva em um Mini PC ou servidor dedicado usando **Kuberne
 
 ```
 Home-Security-DIY/
-├── src/                       # Stack Docker Compose (Desenvolvimento)
-│   ├── docker-compose.yml
-│   └── configs...
-├── k8s/                       # Stack Kubernetes/K3s (Produção)
-│   ├── base/                  # Manifests base
-│   └── overlays/              # Configs específicas (staging/prod)
-├── docs/                      # Documentação de arquitetura
+├── src/
+│   ├── docker-compose.yml             # Stack Docker Compose (desenvolvimento)
+│   ├── dashboard/                     # Dashboard operacional (backend + frontend)
+│   ├── homeassistant/                 # Configurações HA
+│   ├── frigate/                       # Configuração NVR/IA
+│   └── docs/QUICK_START.md
+├── k8s/
+│   ├── base/                          # Manifestos base
+│   ├── overlays/                      # Configs staging/production
+│   └── docs/K3S_SETUP.md
+├── docs/
+│   ├── ARCHITECTURE.md
 │   ├── ARQUITETURA_TECNICA.md
-│   └── ...
-├── prd/                       # Requisitos de Produto (PRDs)
-├── scripts/                   # Scripts de automação e deploy
-└── tasks/                     # Gestão de tarefas do projeto
+│   └── adr/                           # Architecture Decision Records
+├── scripts/                           # Automação e validações
+├── tests/
+└── tasks/
 ```
 
 ---

--- a/docs/MATTER_THREAD_EVALUATION.md
+++ b/docs/MATTER_THREAD_EVALUATION.md
@@ -153,4 +153,4 @@ O **Sonoff ZBDongle-P (CC2652P)** suporta firmware multiprotocolo (Zigbee + Thre
 - [Thread Group](https://www.threadgroup.org/)
 - [Home Assistant Matter Integration](https://www.home-assistant.io/integrations/matter/)
 - [Zigbee2MQTT](https://www.zigbee2mqtt.io/)
-- [ADR-003 - Zigbee como protocolo](docs/adr/ADR-003-zigbee-protocolo.md)
+- [ADR-003 - Zigbee como protocolo](docs/adr/003-adoption-zigbee.md)

--- a/scripts/validate-doc-links.sh
+++ b/scripts/validate-doc-links.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ERRORS=0
+
+check_file_links() {
+    local md_file="$1"
+    local md_dir
+    md_dir="$(cd "$(dirname "$md_file")" && pwd)"
+
+    while IFS= read -r link; do
+        [[ -z "$link" ]] && continue
+        [[ "$link" =~ ^https?:// ]] && continue
+        [[ "$link" =~ ^mailto: ]] && continue
+        [[ "$link" =~ ^# ]] && continue
+
+        local target="${link%%#*}"
+        [[ -z "$target" ]] && continue
+
+        if [[ "$target" = /* ]]; then
+            target_path="${ROOT_DIR}${target}"
+        elif [[ "$target" =~ ^(README\.md|CONTRIBUTING\.md|SECURITY\.md|LICENSE|docs/|k8s/|src/|scripts/|tests/|tasks/|prd/) ]]; then
+            target_path="${ROOT_DIR}/${target}"
+        else
+            target_path="${md_dir}/${target}"
+        fi
+
+        if [[ ! -e "$target_path" ]]; then
+            echo "[FAIL] $md_file -> $link"
+            ERRORS=$((ERRORS + 1))
+        fi
+    done < <(grep -oP '\[[^]]+\]\(\K[^)]+' "$md_file" || true)
+}
+
+while IFS= read -r md; do
+    check_file_links "$md"
+done < <(
+    find "$ROOT_DIR" -maxdepth 3 -type f -name "*.md" \
+        ! -path "$ROOT_DIR/wiki/*" \
+        ! -path "$ROOT_DIR/.github/ISSUE_TEMPLATE/*" \
+        | sort
+)
+
+if [[ $ERRORS -gt 0 ]]; then
+    echo "Found $ERRORS broken local markdown links."
+    exit 1
+fi
+
+echo "All local markdown links are valid."


### PR DESCRIPTION
## Resumo
- alinha seção de estrutura do README com diretórios reais do repositório
- adiciona validação automática de links locais Markdown (`scripts/validate-doc-links.sh`)
- integra validação de links ao workflow de CI
- corrige link quebrado de ADR em documentação técnica

## Validação
- bash scripts/validate-doc-links.sh

Fixes #63
