### PR TITLE
test: garantir uso de Alembic no startup do backend

### DIFF
--- a/tests/backend/test_db_migrations.py
+++ b/tests/backend/test_db_migrations.py
@@ -1,0 +1,34 @@
+import asyncio
+
+from app.db import session as db_session
+
+
+class _FakeConfig:
+    def __init__(self, path):
+        self.path = path
+        self.options = {}
+
+    def set_main_option(self, key, value):
+        self.options[key] = value
+
+
+def test_init_db_uses_alembic_upgrade_head(monkeypatch):
+    calls = {}
+
+    monkeypatch.setattr(db_session, "Config", _FakeConfig)
+
+    def _fake_upgrade(cfg, revision):
+        calls["config"] = cfg
+        calls["revision"] = revision
+
+    async def _fake_to_thread(fn):
+        fn()
+
+    monkeypatch.setattr(db_session.command, "upgrade", _fake_upgrade)
+    monkeypatch.setattr(db_session.asyncio, "to_thread", _fake_to_thread)
+
+    asyncio.run(db_session.init_db())
+
+    assert calls["revision"] == "head"
+    assert calls["config"].options["script_location"].endswith("migrations")
+    assert calls["config"].options["sqlalchemy.url"].startswith("postgresql+psycopg://")


### PR DESCRIPTION
## Resumo
- adiciona teste de regressão para garantir que `init_db()` executa `alembic upgrade head`
- valida que a inicialização usa URL síncrona (`postgresql+psycopg://`) para migração

## Validação
- python3 -m compileall tests/backend/test_db_migrations.py

Fixes #32
