### PR TITLE
feat(frontend): adicionar typecheck e enforcement no CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -110,6 +110,9 @@ jobs:
       - name: Run ESLint
         run: npm run lint
 
+      - name: Run Type Check
+        run: npm run typecheck
+
       - name: Run Vitest
         run: npm run test
 

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -189,7 +189,7 @@ Executar apos cada deploy em ambiente real:
 3. `validate-k8s` — `kubectl kustomize` + `kubeconform`
 4. `lint-shell` — Validar scripts shell com `shellcheck`
 5. `docs-links` — Validar links Markdown locais
-6. `frontend-quality` — `eslint` + `vitest`
+6. `frontend-quality` — `eslint` + `typecheck` + `vitest`
 7. `backend-quality` — `pytest` do backend dashboard
 
 Ver `.github/workflows/validate.yml` para implementacao completa.

--- a/src/dashboard/frontend/package.json
+++ b/src/dashboard/frontend/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint src --ext .js,.jsx",
+    "typecheck": "npx -y typescript tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/src/dashboard/frontend/tsconfig.json
+++ b/src/dashboard/frontend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "checkJs": false,
+    "strict": false,
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.js", "src/**/*.jsx", "vite.config.js", "vitest.config.js"]
+}

--- a/wiki/Testes-e-Validacao.md
+++ b/wiki/Testes-e-Validacao.md
@@ -183,7 +183,7 @@ Execute após cada deploy em ambiente real:
 | `validate-k8s` | kubectl kustomize + kubeconform | Manifests Kubernetes (schema) |
 | `lint-shell` | shellcheck | Scripts .sh |
 | `docs-links` | script local | Links Markdown internos |
-| `frontend-quality` | eslint + vitest | Qualidade e testes do frontend |
+| `frontend-quality` | eslint + typecheck + vitest | Qualidade e testes do frontend |
 | `backend-quality` | pytest | Testes backend do dashboard |
 
 Ver `.github/workflows/validate.yml` para implementação completa.


### PR DESCRIPTION
## Resumo
- adiciona `typecheck` no frontend com TypeScript (`tsconfig.json`)
- integra checagem de tipos no job `frontend-quality` do CI
- atualiza documentação técnica e wiki de testes para refletir pipeline atual

## Validação
- bash scripts/validate-doc-links.sh

Fixes #37
