### PR TITLE
test(ugv): evitar no-op silencioso no comando patrol

### DIFF
--- a/tests/backend/test_ugv_patrol_contract.py
+++ b/tests/backend/test_ugv_patrol_contract.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+UGV_CONTROL = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "drones"
+    / "ugv"
+    / "app"
+    / "ugv_control.py"
+)
+
+
+def test_patrol_command_reports_not_implemented_status():
+    content = UGV_CONTROL.read_text(encoding="utf-8")
+
+    assert "elif command == 'patrol':" in content
+    assert "\"status\": \"not_implemented\"" in content
+    assert "\"command\": \"patrol\"" in content
+    assert "MQTT_TOPIC_STATUS" in content

--- a/wiki/Drones-Autonomos.md
+++ b/wiki/Drones-Autonomos.md
@@ -255,6 +255,12 @@ REGRA-DRONE-10: Whitelist de pessoas autorizadas deve ser configurável.
 4. Dashboard de telemetria em tempo real
 5. Alertas via Telegram
 
+### Estado atual dos comandos UGV (MVP)
+
+- `move`: implementado
+- `defense_arm` / `defense_disarm`: implementados com validações de saúde
+- `patrol`: **ainda não implementado**; o controlador publica status explícito `not_implemented` no tópico `ugv/status` para evitar falso positivo operacional
+
 ---
 
 ## Referências


### PR DESCRIPTION
## Resumo
- adiciona teste de regressão para garantir contrato explícito do comando `patrol`
- documenta na wiki que `patrol` ainda não implementa patrulha e publica `not_implemented`

## Validação
- python3 -m compileall tests/backend/test_ugv_patrol_contract.py
- bash scripts/validate-doc-links.sh

Fixes #47
