### PR TITLE
test(ugv): evitar timeout espúrio de health no bootstrap

### DIFF
--- a/tests/backend/test_ugv_health_bootstrap.py
+++ b/tests/backend/test_ugv_health_bootstrap.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+UGV_CONTROL = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "drones"
+    / "ugv"
+    / "app"
+    / "ugv_control.py"
+)
+
+
+def test_heartbeat_is_reset_immediately_after_mqtt_connect():
+    content = UGV_CONTROL.read_text(encoding="utf-8")
+
+    connect_marker = "client.connect(MQTT_BROKER, MQTT_PORT, 60)"
+    heartbeat_marker = "health.update_heartbeat()"
+    loop_start_marker = "client.loop_start()"
+
+    assert connect_marker in content
+    assert heartbeat_marker in content
+    assert loop_start_marker in content
+
+    connect_pos = content.index(connect_marker)
+    heartbeat_pos = content.index(heartbeat_marker, connect_pos)
+    loop_start_pos = content.index(loop_start_marker, connect_pos)
+
+    assert connect_pos < heartbeat_pos < loop_start_pos

--- a/wiki/Drones-Autonomos.md
+++ b/wiki/Drones-Autonomos.md
@@ -260,6 +260,7 @@ REGRA-DRONE-10: Whitelist de pessoas autorizadas deve ser configurável.
 - `move`: implementado
 - `defense_arm` / `defense_disarm`: implementados com validações de saúde
 - `patrol`: **ainda não implementado**; o controlador publica status explícito `not_implemented` no tópico `ugv/status` para evitar falso positivo operacional
+- Bootstrap MQTT: o monitor de saúde tem heartbeat resetado imediatamente após `client.connect()` para evitar alerta espúrio de timeout no primeiro ciclo
 
 ---
 


### PR DESCRIPTION
## Resumo
- adiciona teste de regressão para garantir reset de heartbeat logo após `client.connect()` do MQTT
- documenta na wiki de drones o comportamento de bootstrap para evitar alerta espúrio no primeiro ciclo

## Validação
- python3 -m compileall tests/backend/test_ugv_health_bootstrap.py
- bash scripts/validate-doc-links.sh

Fixes #48
