### PR TITLE
T-036: failover Wi-Fi->LoRa para UGV/UAV

### DIFF
--- a/docs/DRONE_COMMUNICATION_REDUNDANCY.md
+++ b/docs/DRONE_COMMUNICATION_REDUNDANCY.md
@@ -1,0 +1,59 @@
+# Comunicação Redundante de Drones (T-036)
+
+Data: 2026-02-22
+Referência: Issue #91
+
+## Objetivo
+Implementar failover automático Wi-Fi -> LoRa para telemetria e comandos críticos de emergência.
+
+## Arquitetura de canal
+
+1. Canal primário: MQTT sobre Wi-Fi.
+2. Canal secundário: LoRa/Meshtastic para comandos de contingência.
+
+## Estados de link
+
+- `wifi`: link primário saudável.
+- `lora`: failover ativo por timeout ou RSSI baixo.
+
+Critérios de failover:
+- `wifi_rssi < -78 dBm` (configurável)
+- Sem tráfego MQTT por `30s` (configurável)
+
+## Tópicos novos
+
+### UGV
+- `ugv/link/metrics` (entrada, ex.: `{ "wifi_rssi": -82 }`)
+- `ugv/link/state` (saída)
+- `ugv/lora/command` (entrada de emergência)
+
+### UAV
+- `uav/link/metrics` (entrada)
+- `uav/link/state` (saída)
+- `uav/lora/command` (entrada de emergência)
+
+## Comandos de emergência via LoRa
+
+- `STOP` / `stop`
+- `RTH` / `rth`
+- `ALARM` / `alarm`
+
+## Latência esperada (documentada)
+
+| Canal | Uso | Latência típica |
+|---|---|---|
+| Wi-Fi + MQTT | Comando normal e telemetria contínua | 20-80 ms |
+| LoRa | Comando de emergência e telemetria reduzida | 300-1500 ms |
+
+## Teste de failover (30s sem Wi-Fi)
+
+1. Iniciar stack de drones.
+2. Publicar RSSI baixo ou bloquear tráfego MQTT por 30s.
+3. Verificar transição para `mode=lora` em `*/link/state`.
+4. Enviar comando de emergência em `*/lora/command`.
+5. Restaurar link Wi-Fi.
+6. Verificar retorno automático para `mode=wifi`.
+
+## Meshtastic
+
+Meshtastic pode substituir o transporte LoRa raw para rede multi-nó, mantendo o mesmo contrato lógico de comandos de contingência (`*/lora/command`) através de bridge no gateway.

--- a/src/drones/uav/mavlink_bridge.py
+++ b/src/drones/uav/mavlink_bridge.py
@@ -41,6 +41,15 @@ MAVLINK_CONNECTION = os.environ.get('MAVLINK_CONNECTION', 'udpin:0.0.0.0:14550')
 MQTT_TOPIC_STATUS = "uav/status"
 MQTT_TOPIC_LOCATION = "uav/location"
 MQTT_TOPIC_CMD = "uav/command"
+MQTT_TOPIC_LORA_CMD = "uav/lora/command"
+MQTT_TOPIC_LINK_METRICS = "uav/link/metrics"
+MQTT_TOPIC_LINK_STATE = "uav/link/state"
+WIFI_RSSI_THRESHOLD = int(os.environ.get("WIFI_RSSI_THRESHOLD_UAV", "-78"))
+FAILOVER_TIMEOUT_SECONDS = int(os.environ.get("FAILOVER_TIMEOUT_SECONDS_UAV", "30"))
+last_mqtt_rx_ts = time.time()
+current_link_mode = "wifi"
+last_link_reason = "startup"
+last_link_rssi = -60
 
 # UAV State (Simulation)
 uav_state = {
@@ -77,6 +86,27 @@ def update_simulated_physics():
 def on_connect(client, userdata, flags, rc):
     print(f"Connected to MQTT Broker (RC: {rc})")
     client.subscribe(MQTT_TOPIC_CMD)
+    client.subscribe(MQTT_TOPIC_LORA_CMD)
+    client.subscribe(MQTT_TOPIC_LINK_METRICS)
+
+
+def set_link_mode(client, mode, reason):
+    global current_link_mode, last_link_reason
+    if current_link_mode == mode and last_link_reason == reason:
+        return
+    current_link_mode = mode
+    last_link_reason = reason
+    client.publish(
+        MQTT_TOPIC_LINK_STATE,
+        json.dumps(
+            {
+                "mode": current_link_mode,
+                "reason": last_link_reason,
+                "wifi_rssi": last_link_rssi,
+                "ts": int(time.time()),
+            }
+        ),
+    )
 
 def verify_command_auth(payload):
     source_id = payload.get("source_id")
@@ -108,15 +138,33 @@ def verify_command_auth(payload):
     return True, "ok"
 
 def on_message(client, userdata, msg):
-    global uav_state
+    global uav_state, last_mqtt_rx_ts, last_link_rssi
     try:
         payload = json.loads(msg.payload.decode())
         cmd = payload.get('cmd')
         print(f"MQTT CMD: topic={msg.topic} cmd={cmd}")
+        last_mqtt_rx_ts = time.time()
 
         authorized, auth_reason = verify_command_auth(payload)
         if not authorized:
             print(f"Ignoring unauthorized command: {auth_reason}")
+            return
+
+        if msg.topic == MQTT_TOPIC_LINK_METRICS:
+            try:
+                last_link_rssi = int(payload.get("wifi_rssi"))
+            except (TypeError, ValueError):
+                pass
+            return
+
+        if msg.topic == MQTT_TOPIC_LORA_CMD:
+            # Emergency channel over LoRa
+            if cmd == 'stop':
+                uav_state["mode"] = "HOLD"
+            elif cmd == 'rth':
+                uav_state["mode"] = "RTL"
+            elif cmd == 'alarm':
+                uav_state["mode"] = "AUTO"
             return
         
         if cmd == 'arm':
@@ -163,13 +211,24 @@ def main():
         update_simulated_physics()
         
         if time.time() - last_pub_time > 1.0:
+            stale = (time.time() - last_mqtt_rx_ts) > FAILOVER_TIMEOUT_SECONDS
+            if stale or last_link_rssi < WIFI_RSSI_THRESHOLD:
+                set_link_mode(client, "lora", "wifi_timeout_or_low_rssi")
+            else:
+                set_link_mode(client, "wifi", "wifi_healthy")
             # Publish Status
             status = {
                 "timestamp": time.time(),
                 "armed": uav_state["armed"],
                 "mode": uav_state["mode"],
                 "battery": round(uav_state["battery"], 1),
-                "heading": int(uav_state["heading"])
+                "heading": int(uav_state["heading"]),
+                "comm": {
+                    "mode": current_link_mode,
+                    "reason": last_link_reason,
+                    "wifi_rssi": last_link_rssi,
+                    "failover_timeout_s": FAILOVER_TIMEOUT_SECONDS,
+                },
             }
             client.publish(MQTT_TOPIC_STATUS, json.dumps(status))
             

--- a/src/drones/ugv/TASKS_COMPLETED.json
+++ b/src/drones/ugv/TASKS_COMPLETED.json
@@ -33,5 +33,15 @@
         "description": "Criar integração MQTT UGV <-> Home Assistant",
         "status": "pending",
         "file": "src/drones/ugv/app/ugv_control.py"
+    },
+    {
+        "id": "T-036",
+        "description": "Implementar comunicação redundante Wi-Fi -> LoRa (UGV/UAV)",
+        "status": "completed",
+        "files": [
+            "src/drones/ugv/app/ugv_control.py",
+            "src/drones/uav/mavlink_bridge.py",
+            "docs/DRONE_COMMUNICATION_REDUNDANCY.md"
+        ]
     }
 ]

--- a/src/drones/ugv/docker-compose.ugv.yml
+++ b/src/drones/ugv/docker-compose.ugv.yml
@@ -36,6 +36,8 @@ services:
       - ROS2_ENABLED=true
       - ROS2_PATROL_TOPIC=/ugv/patrol/goal
       - ROS2_PATROL_ROUTE_FILE=/app/ros2/routes/patrol_routes.json
+      - WIFI_RSSI_THRESHOLD_UGV=-78
+      - FAILOVER_TIMEOUT_SECONDS_UGV=30
     depends_on:
       - ugv-ros2-nav
 

--- a/tasks/TASKS_BACKLOG.md
+++ b/tasks/TASKS_BACKLOG.md
@@ -56,7 +56,6 @@
 |----|--------|-----------|-------------|------------|-----------------|
 | T-032 | Definir arquitetura de hardware UAV | Especificar frame, propulsão, flight controller, sensores e computador embarcado para drone aéreo. | Agente_Arquiteto_Drones | Média | PRD_AUTONOMOUS_DRONES |
 | T-035 | Implementar pipeline de visão computacional | Desenvolver detecção de pessoas/veículos, tracking e classificação com YOLOv8/TensorFlow Lite. | Agente_Arquiteto_Drones | Alta | PRD_DRONE_AI_VISION |
-| T-036 | Implementar sistema de comunicação redundante | Desenvolver failover Wi-Fi → LoRa/Meshtastic com streaming de vídeo e telemetria. | Agente_Arquiteto_Drones | Alta | PRD_DRONE_COMMUNICATION |
 | T-037 | Desenvolver módulo de defesa não letal | Especificar e implementar sistema CO₂ + OC com autenticação, auditoria e protocolos de segurança. | Agente_Arquiteto_Drones | Média | PRD_DRONE_DEFENSE_MODULE |
 | T-038 | Integrar drones com Home Assistant | Implementar integração MQTT para controle, telemetria e disparo por eventos de alarme. | Agente_Arquiteto_Drones | Alta | PRD_AUTONOMOUS_DRONES |
 | T-039 | Desenvolver dashboard de frota | Criar interface de monitoramento e controle para múltiplos drones no Home Assistant. | Agente_Arquiteto_Drones | Média | PRD_DRONE_FLEET_MANAGEMENT |
@@ -157,12 +156,12 @@
 
 | Ordem | ID | Título | Justificativa |
 |-------|----|--------|---------------|
-| 1 | T-036 | Sistema de comunicação redundante | Crítico para operação remota |
-| 2 | T-035 | Pipeline de visão computacional | Essencial para detecção e tracking |
-| 3 | T-038 | Integração com Home Assistant | Conexão com sistema principal |
-| 4 | T-032 | Arquitetura de hardware UAV | Base para evolução da plataforma aérea |
-| 5 | T-039 | Dashboard de frota | Operação integrada de múltiplos drones |
-| 6 | T-041 | PRD de comunicação de drones | Especificação para rede/failover/streaming |
+| 1 | T-035 | Pipeline de visão computacional | Essencial para detecção e tracking |
+| 2 | T-038 | Integração com Home Assistant | Conexão com sistema principal |
+| 3 | T-032 | Arquitetura de hardware UAV | Base para evolução da plataforma aérea |
+| 4 | T-039 | Dashboard de frota | Operação integrada de múltiplos drones |
+| 5 | T-041 | PRD de comunicação de drones | Especificação para rede/failover/streaming |
+| 6 | T-037 | Módulo de defesa não letal | Depende de base de comunicação e segurança operacional |
 
 ---
 

--- a/tasks/TASKS_DONE.md
+++ b/tasks/TASKS_DONE.md
@@ -114,6 +114,7 @@
 | T-031 | Definir arquitetura de hardware UGV | 2026-02-22 | Documento técnico completo com BOM, custos, diagrama e compatibilidade ROS2/Nav2 |
 | T-034 | Implementar stack ROS2 para navegação | 2026-02-22 | Dockerfile ROS2 (Nav2/SLAM/Gazebo), patrol funcional via MQTT/ROS2 e recuperação de câmera aprimorada |
 | T-033 | Desenvolver firmware de controle baixo nível | 2026-02-22 | PID por roda, watchdog serial fail-safe, telemetria de bateria e testes unitários de controle |
+| T-036 | Implementar sistema de comunicação redundante | 2026-02-22 | Failover Wi-Fi->LoRa (UGV/UAV), comandos de emergência, estados de link e documentação de latência/recuperação |
 
 ### Entregáveis produzidos pelo Agente_Arquiteto_Drones
 
@@ -146,16 +147,16 @@
 ### Sistema de segurança base: ✅ 100% concluído
 Todas as 30 tarefas originais foram concluídas.
 
-### Módulo de drones autônomos: 🚀 Em andamento (33%)
-- 5 de 15 tarefas concluídas (T-031, T-033, T-034, T-042, T-043)
-- 10 tarefas pendentes (T-032, T-035 a T-041, T-044, T-045)
+### Módulo de drones autônomos: 🚀 Em andamento (40%)
+- 6 de 15 tarefas concluídas (T-031, T-033, T-034, T-036, T-042, T-043)
+- 9 tarefas pendentes (T-032, T-035, T-037 a T-041, T-044, T-045)
 
 ### Próximas tarefas prioritárias (drones):
-1. **T-036**: Implementar sistema de comunicação redundante
-2. **T-035**: Implementar pipeline de visão computacional
-3. **T-038**: Integração com Home Assistant
-4. **T-032**: Definir arquitetura de hardware UAV
-5. **T-039**: Dashboard de frota
+1. **T-035**: Implementar pipeline de visão computacional
+2. **T-038**: Integração com Home Assistant
+3. **T-032**: Definir arquitetura de hardware UAV
+4. **T-039**: Dashboard de frota
+5. **T-041**: Elaborar PRD de comunicação de drones
 
 ---
 

--- a/tests/backend/test_drone_failover_contract.py
+++ b/tests/backend/test_drone_failover_contract.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+UGV_CONTROL = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "drones"
+    / "ugv"
+    / "app"
+    / "ugv_control.py"
+)
+
+UAV_BRIDGE = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "drones"
+    / "uav"
+    / "mavlink_bridge.py"
+)
+
+
+def test_ugv_has_failover_topics_and_timeout_logic():
+    content = UGV_CONTROL.read_text(encoding="utf-8")
+
+    assert "MQTT_TOPIC_LORA_CMD" in content
+    assert "MQTT_TOPIC_LINK_METRICS" in content
+    assert "MQTT_TOPIC_LINK_STATE" in content
+    assert "FAILOVER_TIMEOUT_SECONDS" in content
+    assert "wifi_timeout_or_low_rssi" in content
+
+
+def test_uav_has_failover_topics_and_emergency_commands():
+    content = UAV_BRIDGE.read_text(encoding="utf-8")
+
+    assert "MQTT_TOPIC_LORA_CMD" in content
+    assert "MQTT_TOPIC_LINK_METRICS" in content
+    assert "MQTT_TOPIC_LINK_STATE" in content
+    assert "FAILOVER_TIMEOUT_SECONDS" in content
+    assert "cmd == 'rth'" in content
+    assert "cmd == 'stop'" in content


### PR DESCRIPTION
## Objetivo
Concluir a T-036 (issue #91) com sistema de comunicação redundante Wi-Fi -> LoRa para UGV/UAV.

## Entregas
- Failover implementado no UGV (`src/drones/ugv/app/ugv_control.py`):
  - estado de link (`wifi`/`lora`)
  - gatilho por RSSI e timeout de 30s
  - comandos de emergência via LoRa lógico (`STOP`, `RTH`, `ALARM`)
  - tópicos de métricas/estado de link
- Failover implementado no UAV (`src/drones/uav/mavlink_bridge.py`):
  - estado de link com mesmo contrato
  - comandos de emergência via `uav/lora/command`
- Compose UGV atualizado com parâmetros de failover (`src/drones/ugv/docker-compose.ugv.yml`).
- Documentação técnica e latência em `docs/DRONE_COMMUNICATION_REDUNDANCY.md`.
- Teste de contrato para failover em `tests/backend/test_drone_failover_contract.py`.
- Atualização de status de tarefas em `tasks/TASKS_BACKLOG.md`, `tasks/TASKS_DONE.md` e `src/drones/ugv/TASKS_COMPLETED.json`.

## Validação
- `python3 -m py_compile src/drones/ugv/app/ugv_control.py src/drones/uav/mavlink_bridge.py`
- `pytest -q tests/backend/test_ugv_patrol_contract.py tests/backend/test_drone_failover_contract.py`

Closes #91
