### PR TITLE
[TASK] T-038: Integrar drones com Home Assistant via MQTT

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ O projeto inclui uma camada reativa avançada com **frota modular de drones aut�
 **Documentação do Módulo Drones:**
 - 📄 [Arquitetura UGV (Terrestre)](docs/ARQUITETURA_HARDWARE_UGV.md)
 - 📄 [Arquitetura UAV (Aéreo)](docs/ARQUITETURA_HARDWARE_UAV.md)
+- 🔗 [Integração MQTT com Home Assistant](docs/DRONE_HOMEASSISTANT_MQTT_INTEGRATION.md)
 - 🛠️ [Guia de Montagem UGV](docs/GUIA_MONTAGEM_UGV.md)
 - 🛡️ [Módulo de Defesa e Segurança](prd/PRD_DRONE_DEFENSE_MODULE.md)
 

--- a/docs/DRONE_HOMEASSISTANT_MQTT_INTEGRATION.md
+++ b/docs/DRONE_HOMEASSISTANT_MQTT_INTEGRATION.md
@@ -1,0 +1,83 @@
+# Integração MQTT Drones + Home Assistant (T-038)
+
+Este documento descreve os tópicos MQTT usados para integração entre Home Assistant e os módulos UGV/UAV.
+
+## Objetivo
+
+- Controle manual no Home Assistant (`start_patrol`, `return_home`, `stop`, `inspect_zone`)
+- Telemetria de status e bateria para entidades HA
+- Disparo automático por evento de alarme
+- Notificação push quando há detecção no pipeline de visão dos drones
+
+## Tópicos de comando (HA -> Drones)
+
+- `ugv/command`
+- `uav/command`
+
+Payloads suportados:
+
+```json
+{"cmd":"patrol","route":"perimeter_day","source_id":"homeassistant"}
+{"cmd":"return_home","source_id":"homeassistant"}
+{"cmd":"stop","source_id":"homeassistant"}
+{"cmd":"inspect_zone","source_id":"homeassistant"}
+```
+
+## Tópicos de telemetria (Drones -> HA)
+
+- `ugv/status`
+  - Campos relevantes: `state`, `battery`, `wifi_signal`, `comm.mode`
+- `uav/status`
+  - Campos relevantes: `mode`, `armed`, `battery`, `heading`, `comm.mode`
+- `uav/location`
+  - Campos relevantes: `latitude`, `longitude`, `altitude`
+- `ugv/vision/detections`
+- `uav/vision/detections`
+- `ugv/vision/safety`
+- `uav/vision/safety`
+
+## Entidades e botões no Home Assistant
+
+Arquivo: `src/homeassistant/mqtt.yaml`
+
+- Sensores:
+  - `sensor.ugv_battery`
+  - `sensor.ugv_status`
+  - `sensor.uav_battery`
+  - `sensor.uav_status`
+- Botões:
+  - `button.ugv_start_patrol`
+  - `button.ugv_return_home`
+  - `button.ugv_emergency_stop`
+  - `button.uav_inspect_zone`
+  - `button.uav_return_home`
+  - `button.uav_stop`
+
+## Automações no Home Assistant
+
+Arquivo: `src/homeassistant/automations.yaml`
+
+- `alarm_triggered_dispatch_uav`
+  - Alarme disparado -> publica `inspect_zone` em `uav/command`
+- `alarm_triggered_dispatch_ugv`
+  - Alarme disparado -> publica `patrol` em `ugv/command`
+- `drone_intrusion_notification`
+  - Deteções em `ugv/vision/detections` ou `uav/vision/detections` -> `notify.notify`
+
+## Segurança de comandos MQTT
+
+Por padrão, os bridges UGV/UAV validam comandos por HMAC:
+
+- `COMMAND_HMAC_SECRET_UGV`
+- `COMMAND_HMAC_SECRET_UAV`
+
+Para integração rápida com botões do Home Assistant sem assinatura HMAC, habilitar explicitamente:
+
+- `ALLOW_UNSIGNED_HOMEASSISTANT_COMMANDS_UGV=true`
+- `ALLOW_UNSIGNED_HOMEASSISTANT_COMMANDS_UAV=true`
+
+Recomendação para produção:
+
+- Usar assinatura HMAC e timestamp para todos os emissores
+- Restringir `COMMAND_ALLOWED_SOURCES_*`
+- Separar broker MQTT em rede/VLAN de automação

--- a/src/.env.example
+++ b/src/.env.example
@@ -82,6 +82,8 @@ COMMAND_ALLOWED_SOURCES_UGV=dashboard,homeassistant
 COMMAND_ALLOWED_SOURCES_UAV=dashboard,homeassistant
 COMMAND_MAX_SKEW_SECONDS_UGV=30
 COMMAND_MAX_SKEW_SECONDS_UAV=30
+ALLOW_UNSIGNED_HOMEASSISTANT_COMMANDS_UGV=false
+ALLOW_UNSIGNED_HOMEASSISTANT_COMMANDS_UAV=false
 
 # --- Backup ---
 # Se definido, scripts/backup.sh criptografa backups de configuração com AES-256.

--- a/src/drones/ugv/docker-compose.ugv.yml
+++ b/src/drones/ugv/docker-compose.ugv.yml
@@ -32,6 +32,7 @@ services:
       - COMMAND_HMAC_SECRET_UGV=CHANGE_ME_ugv_hmac_secret
       - COMMAND_ALLOWED_SOURCES_UGV=dashboard,homeassistant
       - COMMAND_MAX_SKEW_SECONDS_UGV=30
+      - ALLOW_UNSIGNED_HOMEASSISTANT_COMMANDS_UGV=false
       - RTSP_URI=rtsp://mediamtx:8554/cam
       - ROS2_ENABLED=true
       - ROS2_PATROL_TOPIC=/ugv/patrol/goal

--- a/src/homeassistant/automations.yaml
+++ b/src/homeassistant/automations.yaml
@@ -140,6 +140,38 @@
         brightness: 255
 
 # ---------------------------------------------------------------------------
+# Alarme disparado -> UAV inspeciona zona de alerta (T-038)
+# ---------------------------------------------------------------------------
+- id: alarm_triggered_dispatch_uav
+  alias: "Segurança - Alarme disparado - Acionar UAV"
+  description: "Dispara comando MQTT para o UAV inspecionar a zona de alerta"
+  trigger:
+    - platform: state
+      entity_id: alarm_control_panel.alarmo
+      to: "triggered"
+  action:
+    - service: mqtt.publish
+      data:
+        topic: uav/command
+        payload: '{"cmd":"inspect_zone","source_id":"homeassistant"}'
+
+# ---------------------------------------------------------------------------
+# Alarme disparado -> UGV patrulha perímetro (T-038)
+# ---------------------------------------------------------------------------
+- id: alarm_triggered_dispatch_ugv
+  alias: "Segurança - Alarme disparado - Acionar UGV"
+  description: "Dispara comando MQTT para o UGV iniciar patrulha de perímetro"
+  trigger:
+    - platform: state
+      entity_id: alarm_control_panel.alarmo
+      to: "triggered"
+  action:
+    - service: mqtt.publish
+      data:
+        topic: ugv/command
+        payload: '{"cmd":"patrol","route":"perimeter_day","source_id":"homeassistant"}'
+
+# ---------------------------------------------------------------------------
 # Desativar resposta ao desarmar alarme
 # ---------------------------------------------------------------------------
 - id: alarm_disarmed_response
@@ -217,6 +249,29 @@
         data:
           image: >
             /api/frigate/notifications/{{ trigger.payload_json['after']['id'] }}/snapshot.jpg
+
+# ---------------------------------------------------------------------------
+# Notificação de intruso detectado pelos drones (T-038)
+# ---------------------------------------------------------------------------
+- id: drone_intrusion_notification
+  alias: "Segurança - Intruso detectado por drone"
+  description: "Notifica quando o pipeline de visão de UGV/UAV reporta detecção"
+  trigger:
+    - platform: mqtt
+      topic: ugv/vision/detections
+    - platform: mqtt
+      topic: uav/vision/detections
+  condition:
+    - condition: template
+      value_template: "{{ trigger.payload_json.count | int(0) > 0 }}"
+  action:
+    - service: notify.notify
+      data:
+        title: "🚨 Intruso detectado por drone"
+        message: >
+          {% set count = trigger.payload_json.count | int(0) %}
+          {% set topic = trigger.topic %}
+          Alerta via {{ topic }}: {{ count }} detecção(ões) às {{ now().strftime('%H:%M:%S') }}.
 
 # =============================================================================
 # MONITORAMENTO DE SAÚDE DO SISTEMA

--- a/src/homeassistant/mqtt.yaml
+++ b/src/homeassistant/mqtt.yaml
@@ -18,7 +18,7 @@ sensor:
     device_class: signal_strength
     icon: mdi:wifi
 
-  - name: "UGV State"
+  - name: "UGV Status"
     state_topic: "ugv/status"
     value_template: "{{ value_json.state }}"
     icon: mdi:robot
@@ -46,6 +46,16 @@ sensor:
     state_topic: "uav/status"
     value_template: "{{ value_json.mode }}"
     icon: mdi:airplane-takeoff
+
+  - name: "UAV Status"
+    state_topic: "uav/status"
+    value_template: >
+      {% if value_json.armed %}
+        airborne_{{ value_json.mode | lower }}
+      {% else %}
+        ground_{{ value_json.mode | lower }}
+      {% endif %}
+    icon: mdi:airplane
 
 # --- Binary Sensors ---
 binary_sensor:
@@ -87,13 +97,33 @@ binary_sensor:
 button:
   - name: "UGV Start Patrol"
     command_topic: "ugv/command"
-    payload_press: '{"cmd": "patrol"}'
+    payload_press: '{"cmd":"patrol","route":"perimeter_day","source_id":"homeassistant"}'
     icon: mdi:shield-check
+
+  - name: "UGV Return Home"
+    command_topic: "ugv/command"
+    payload_press: '{"cmd":"return_home","source_id":"homeassistant"}'
+    icon: mdi:home-map-marker
 
   - name: "UGV Emergency Stop"
     command_topic: "ugv/command"
-    payload_press: '{"cmd": "stop"}'
+    payload_press: '{"cmd":"stop","source_id":"homeassistant"}'
     icon: mdi:alert-octagon-outline
+
+  - name: "UAV Inspect Zone"
+    command_topic: "uav/command"
+    payload_press: '{"cmd":"inspect_zone","source_id":"homeassistant"}'
+    icon: mdi:airplane-search
+
+  - name: "UAV Return Home"
+    command_topic: "uav/command"
+    payload_press: '{"cmd":"return_home","source_id":"homeassistant"}'
+    icon: mdi:airplane-landing
+
+  - name: "UAV STOP"
+    command_topic: "uav/command"
+    payload_press: '{"cmd":"stop","source_id":"homeassistant"}'
+    icon: mdi:alert-octagon
 # --- Camera ---
 # Note: Cameras are usually configured in 'camera:' section, not under 'mqtt:' unless it's an MQTT camera.
 # We will use Generic Camera integration for RTSP, configured in configuration.yaml or UI.

--- a/tasks/TASKS_BACKLOG.md
+++ b/tasks/TASKS_BACKLOG.md
@@ -55,13 +55,14 @@
 | ID | Título | Descrição | Responsável | Prioridade | PRD relacionado |
 |----|--------|-----------|-------------|------------|-----------------|
 | T-037 | Desenvolver módulo de defesa não letal | Especificar e implementar sistema CO₂ + OC com autenticação, auditoria e protocolos de segurança. | Agente_Arquiteto_Drones | Média | PRD_DRONE_DEFENSE_MODULE |
-| T-038 | Integrar drones com Home Assistant | Implementar integração MQTT para controle, telemetria e disparo por eventos de alarme. | Agente_Arquiteto_Drones | Alta | PRD_AUTONOMOUS_DRONES |
 | T-039 | Desenvolver dashboard de frota | Criar interface de monitoramento e controle para múltiplos drones no Home Assistant. | Agente_Arquiteto_Drones | Média | PRD_DRONE_FLEET_MANAGEMENT |
 | T-040 | Elaborar PRD do módulo de defesa | Detalhar requisitos funcionais e não funcionais do sistema de defesa não letal. | Agente_Documentador | Média | PRD_DRONE_DEFENSE_MODULE |
 | T-041 | Elaborar PRD de comunicação de drones | Detalhar requisitos de rede, protocolos, failover e streaming para drones. | Agente_Documentador | Média | PRD_DRONE_COMMUNICATION |
 | T-044 | Criar guia de montagem UGV | Documentar passo a passo de montagem do drone terrestre com BOM e instruções. | Agente_Documentador | Baixa | PRD_AUTONOMOUS_DRONES |
 | T-045 | Criar guia de montagem UAV | Documentar passo a passo de montagem do drone aéreo com BOM e instruções. | Agente_Documentador | Baixa | PRD_AUTONOMOUS_DRONES |
 
+> ✅ T-038 (Integração MQTT drones + Home Assistant) concluída em 2026-02-22
+>
 > ✅ T-042 (Pesquisar normas ANAC/DECEA) e T-043 (Pesquisar legislação defesa não letal) concluídas em 2026-02-12
 
 ---
@@ -130,9 +131,9 @@
 | Normas e compliance | 7 | 7 | 0 |
 | Documentação e PRDs | 4 | 4 | 0 |
 | Privacidade e segurança | 2 | 2 | 0 |
-| Drones autônomos | 15 | 15 | 0 |
+| Drones autônomos | 15 | 9 | 6 |
 | **Revisão e melhorias** | **23** | **23** | **0** |
-| **Total** | **68** | **68** | **0** |
+| **Total** | **68** | **62** | **6** |
 
 ---
 
@@ -154,12 +155,12 @@
 
 | Ordem | ID | Título | Justificativa |
 |-------|----|--------|---------------|
-| 1 | T-038 | Integração com Home Assistant | Conexão com sistema principal |
-| 2 | T-039 | Dashboard de frota | Operação integrada de múltiplos drones |
-| 3 | T-041 | PRD de comunicação de drones | Especificação para rede/failover/streaming |
-| 4 | T-037 | Módulo de defesa não letal | Depende de base de comunicação e segurança operacional |
-| 5 | T-040 | PRD do módulo de defesa | Formalização de requisitos e riscos legais |
-| 6 | T-044 | Guia de montagem UGV | Habilita replicabilidade do hardware terrestre |
+| 1 | T-039 | Dashboard de frota | Operação integrada de múltiplos drones |
+| 2 | T-041 | PRD de comunicação de drones | Especificação para rede/failover/streaming |
+| 3 | T-037 | Módulo de defesa não letal | Depende de base de comunicação e segurança operacional |
+| 4 | T-040 | PRD do módulo de defesa | Formalização de requisitos e riscos legais |
+| 5 | T-044 | Guia de montagem UGV | Habilita replicabilidade do hardware terrestre |
+| 6 | T-045 | Guia de montagem UAV | Replicabilidade da plataforma aérea |
 
 ---
 

--- a/tasks/TASKS_DONE.md
+++ b/tasks/TASKS_DONE.md
@@ -117,6 +117,7 @@
 | T-036 | Implementar sistema de comunicação redundante | 2026-02-22 | Failover Wi-Fi->LoRa (UGV/UAV), comandos de emergência, estados de link e documentação de latência/recuperação |
 | T-035 | Implementar pipeline de visão computacional | 2026-02-22 | YOLOv8/TFLite no UGV, tracking estilo SORT, filtro de segurança e pipeline correspondente no UAV |
 | T-032 | Definir arquitetura de hardware UAV | 2026-02-22 | Arquitetura de hardware aérea completa com BOM, autonomia, comunicação redundante e critérios de aceite cobertos |
+| T-038 | Integrar drones com Home Assistant | 2026-02-22 | Integração MQTT completa (telemetria/status, botões de comando, automações de alarme e notificações de detecção) |
 
 ### Entregáveis produzidos pelo Agente_Arquiteto_Drones
 
@@ -139,8 +140,8 @@
 | Normas e compliance | 7 | 7 | 100% |
 | Documentação e PRDs | 4 | 4 | 100% |
 | Privacidade e segurança | 2 | 2 | 100% |
-| Drones autônomos | 15 | 2 | 13% |
-| **Total** | **45** | **32** | **71%** |
+| Drones autônomos | 15 | 9 | 60% |
+| **Total** | **45** | **39** | **87%** |
 
 ---
 
@@ -149,16 +150,16 @@
 ### Sistema de segurança base: ✅ 100% concluído
 Todas as 30 tarefas originais foram concluídas.
 
-### Módulo de drones autônomos: 🚀 Em andamento (53%)
-- 8 de 15 tarefas concluídas (T-031, T-032, T-033, T-034, T-035, T-036, T-042, T-043)
-- 7 tarefas pendentes (T-037 a T-041, T-044, T-045)
+### Módulo de drones autônomos: 🚀 Em andamento (60%)
+- 9 de 15 tarefas concluídas (T-031, T-032, T-033, T-034, T-035, T-036, T-038, T-042, T-043)
+- 6 tarefas pendentes (T-037, T-039, T-040, T-041, T-044, T-045)
 
 ### Próximas tarefas prioritárias (drones):
-1. **T-038**: Integração com Home Assistant
-2. **T-039**: Dashboard de frota
-3. **T-041**: Elaborar PRD de comunicação de drones
-4. **T-037**: Desenvolver módulo de defesa não letal
-5. **T-040**: Elaborar PRD do módulo de defesa
+1. **T-039**: Dashboard de frota
+2. **T-041**: Elaborar PRD de comunicação de drones
+3. **T-037**: Desenvolver módulo de defesa não letal
+4. **T-040**: Elaborar PRD do módulo de defesa
+5. **T-044**: Criar guia de montagem UGV
 
 ---
 

--- a/tests/backend/test_drone_homeassistant_mqtt_contract.py
+++ b/tests/backend/test_drone_homeassistant_mqtt_contract.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MQTT_YAML = ROOT / "src" / "homeassistant" / "mqtt.yaml"
+AUTOMATIONS = ROOT / "src" / "homeassistant" / "automations.yaml"
+UGV_CONTROL = ROOT / "src" / "drones" / "ugv" / "app" / "ugv_control.py"
+UAV_BRIDGE = ROOT / "src" / "drones" / "uav" / "mavlink_bridge.py"
+
+
+def test_homeassistant_mqtt_entities_for_drone_battery_and_status_exist():
+    content = MQTT_YAML.read_text(encoding="utf-8")
+
+    assert 'name: "UGV Battery"' in content
+    assert 'name: "UGV Status"' in content
+    assert 'name: "UAV Battery"' in content
+    assert 'name: "UAV Status"' in content
+
+
+def test_homeassistant_has_drone_control_buttons():
+    content = MQTT_YAML.read_text(encoding="utf-8")
+
+    assert 'name: "UGV Start Patrol"' in content
+    assert 'name: "UGV Return Home"' in content
+    assert 'name: "UGV Emergency Stop"' in content
+    assert 'name: "UAV Inspect Zone"' in content
+    assert 'name: "UAV Return Home"' in content
+    assert 'name: "UAV STOP"' in content
+
+
+def test_alarm_trigger_automations_dispatch_uav_and_ugv():
+    content = AUTOMATIONS.read_text(encoding="utf-8")
+
+    assert "id: alarm_triggered_dispatch_uav" in content
+    assert 'topic: uav/command' in content
+    assert '"cmd":"inspect_zone"' in content
+    assert "id: alarm_triggered_dispatch_ugv" in content
+    assert 'topic: ugv/command' in content
+    assert '"cmd":"patrol"' in content
+
+
+def test_intrusion_notification_automation_exists():
+    content = AUTOMATIONS.read_text(encoding="utf-8")
+
+    assert "id: drone_intrusion_notification" in content
+    assert "topic: ugv/vision/detections" in content
+    assert "topic: uav/vision/detections" in content
+    assert "Intruso detectado por drone" in content
+
+
+def test_unsigned_homeassistant_toggle_supported_in_ugv_and_uav():
+    ugv_content = UGV_CONTROL.read_text(encoding="utf-8")
+    uav_content = UAV_BRIDGE.read_text(encoding="utf-8")
+
+    assert "ALLOW_UNSIGNED_HOMEASSISTANT_COMMANDS_UGV" in ugv_content
+    assert "unsigned_homeassistant_allowed" in ugv_content
+    assert "ALLOW_UNSIGNED_HOMEASSISTANT_COMMANDS_UAV" in uav_content
+    assert "unsigned_homeassistant_allowed" in uav_content


### PR DESCRIPTION
## Resumo
Conclui a T-038 com integracao MQTT ponta a ponta entre Home Assistant e drones UGV/UAV.

## Entregas
- Entidades HA para bateria/status de UGV e UAV em src/homeassistant/mqtt.yaml.
- Botoes de controle manual (patrol, return_home, stop, inspect_zone) via MQTT.
- Automacoes HA para alarme disparado acionar UAV (inspect_zone) e UGV (patrol).
- Notificacao push quando pipeline de visao dos drones reporta deteccoes.
- Correcao de autenticacao para permitir comando sem assinatura do Home Assistant quando habilitado por env var.
- Documentacao dos topicos MQTT em docs/DRONE_HOMEASSISTANT_MQTT_INTEGRATION.md.
- Teste de contrato para integracao HA+drones em tests/backend/test_drone_homeassistant_mqtt_contract.py.
- Atualizacao de status em tasks/TASKS_BACKLOG.md e tasks/TASKS_DONE.md.

## Validacao
pytest -q tests/backend/test_drone_homeassistant_mqtt_contract.py tests/backend/test_drone_failover_contract.py tests/backend/test_drone_vision_pipeline_contract.py tests/backend/test_ugv_patrol_contract.py

Resultado: 11 passed.

Closes #93
