### PR TITLE
[Compliance] #108 Checklist Matter/Thread e decisão de migração

### DIFF
--- a/docs/COMPLIANCE_CHECKLIST_EXECUTION.md
+++ b/docs/COMPLIANCE_CHECKLIST_EXECUTION.md
@@ -54,8 +54,9 @@ Arquivo: `tasks/COMPLIANCE_CHECKLIST_AUDIT_2026-02-22.md`
 - Manual pendente: execucao em ambiente ativo (HA, Dashboard, Frigate, API, sensores, VPN).
 
 ### #108 - Matter/Thread
-- Automatizado: documento de avaliacao presente.
-- Manual pendente: validacao de mercado BR, preco, maturidade de suporte e decisao final.
+- Automatizado: decisao operacional registrada com checklist objetivo.
+- Evidencias: `docs/MATTER_THREAD_EVALUATION.md` e `docs/MATTER_THREAD_DECISION_2026-02-22.md`.
+- Resultado atual: manter Zigbee e reavaliar em 6 meses.
 
 ## Como executar a auditoria
 ```bash

--- a/docs/MATTER_THREAD_DECISION_2026-02-22.md
+++ b/docs/MATTER_THREAD_DECISION_2026-02-22.md
@@ -1,0 +1,25 @@
+# Decisão Matter/Thread - 2026-02-22 (Issue #108)
+
+## Contexto
+
+O sistema atual opera com Zigbee 3.0 como base para sensores e automações críticas de segurança.
+
+## Checklist objetivo de migração
+
+- [ ] Sirenes Matter disponíveis e testadas no mercado nacional
+- [ ] Sensores de segurança Matter (fumaça, gás, abertura) amplamente disponíveis
+- [ ] Preços competitivos com Zigbee no Brasil
+- [ ] Home Assistant com suporte Matter estável e completo
+- [ ] Alarmo com suporte nativo a dispositivos Matter
+
+## Resultado da avaliação (2026-02-22)
+
+- Itens acima: **não comprovados integralmente** para o ambiente alvo.
+- Decisão: **não migrar agora**.
+- Estratégia: manter Zigbee e adotar apenas dispositivos dual-protocol em novas compras.
+
+## Próxima revisão
+
+- Data alvo: **2026-08-22** (6 meses).
+- Critério para iniciar piloto Matter:
+  - todos os itens do checklist marcados como concluídos.

--- a/docs/MATTER_THREAD_EVALUATION.md
+++ b/docs/MATTER_THREAD_EVALUATION.md
@@ -143,7 +143,14 @@ O **Sonoff ZBDongle-P (CC2652P)** suporta firmware multiprotocolo (Zigbee + Thre
 
 **Matter/Thread e o futuro do smart home, mas Zigbee 3.0 e a escolha certa para seguranca residencial hoje.** O ecossistema Zigbee e mais completo, mais barato e mais maduro para as necessidades do projeto. A migracao deve ser gradual e oportunista, priorizando dispositivos dual-protocol.
 
-**Proxima revisao**: Janeiro 2027 (reavaliar estado do Matter)
+### Decisao operacional registrada em 2026-02-22
+
+- Decisao: **manter Zigbee** como protocolo principal.
+- Motivo: pre-condicoes de migracao Matter/Thread ainda nao foram comprovadas no ambiente alvo.
+- Acao: reavaliar em 6 meses com checklist objetivo.
+- Registro: `docs/MATTER_THREAD_DECISION_2026-02-22.md`.
+
+**Proxima revisao**: 2026-08-22 (reavaliar estado do Matter)
 
 ---
 

--- a/tests/backend/test_matter_thread_decision_contract.py
+++ b/tests/backend/test_matter_thread_decision_contract.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+EVALUATION = ROOT / "docs" / "MATTER_THREAD_EVALUATION.md"
+DECISION = ROOT / "docs" / "MATTER_THREAD_DECISION_2026-02-22.md"
+
+
+def test_matter_evaluation_contains_operational_decision_and_review_date():
+    content = EVALUATION.read_text(encoding="utf-8")
+
+    assert "Decisao operacional registrada em 2026-02-22" in content
+    assert "docs/MATTER_THREAD_DECISION_2026-02-22.md" in content
+    assert "Proxima revisao" in content
+    assert "2026-08-22" in content
+
+
+def test_matter_decision_log_contains_migration_checklist():
+    content = DECISION.read_text(encoding="utf-8")
+
+    assert "Checklist objetivo de migração" in content
+    assert "Sirenes Matter disponíveis" in content
+    assert "não migrar agora" in content
+    assert "2026-08-22" in content


### PR DESCRIPTION
## Resumo
Conclui a issue #108 com decisão operacional formal sobre Matter/Thread, checklist objetivo de migração e agendamento de reavaliação em 6 meses.

## Entregas
- Atualização da avaliação principal:
  - `docs/MATTER_THREAD_EVALUATION.md`
- Registro formal de decisão:
  - `docs/MATTER_THREAD_DECISION_2026-02-22.md`
- Atualização do consolidado de compliance:
  - `docs/COMPLIANCE_CHECKLIST_EXECUTION.md`
- Teste de contrato:
  - `tests/backend/test_matter_thread_decision_contract.py`

## Decisão
- Manter Zigbee como protocolo principal no momento.
- Reavaliar checklist de migração Matter em **2026-08-22**.

## Validação
- `pytest -q tests/backend/test_matter_thread_decision_contract.py tests/backend/test_integration_checklist_contract.py`
- Resultado: 4 passed

Closes #108
