### PR TITLE
[RedTeam] RT-01 - Exposição de portas Frigate (RTSP/WebRTC)

### DIFF
--- a/docs/NETWORK_SECURITY_VLAN_CREDENTIALS_CHECKLIST.md
+++ b/docs/NETWORK_SECURITY_VLAN_CREDENTIALS_CHECKLIST.md
@@ -20,6 +20,8 @@ Evidência técnica esperada: export de regras do firewall/switch.
 - [ ] SSID IoT com política segregada.
 - [ ] Firewall com regras restritivas aplicadas.
 - [ ] VPN WireGuard/Tailscale funcional para acesso remoto.
+- [x] Frigate (8554/8555) restrito a loopback no host.
+  Evidência: `src/docker-compose.yml`
 
 ## 3. MQTT/TLS
 

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -118,9 +118,9 @@ services:
     shm_size: "256mb"
     ports:
       - "127.0.0.1:5000:5000" # Web UI
-      - "8554:8554" # RTSP restream
-      - "8555:8555" # WebRTC
-      - "8555:8555/udp"
+      - "127.0.0.1:8554:8554" # RTSP restream (loopback only)
+      - "127.0.0.1:8555:8555" # WebRTC (loopback only)
+      - "127.0.0.1:8555:8555/udp"
     volumes:
       - ./frigate/config.yml:/config/config.yml:ro
       - ${FRIGATE_MEDIA_PATH:-./frigate/media}:/media/frigate

--- a/tests/backend/test_frigate_port_exposure_contract.py
+++ b/tests/backend/test_frigate_port_exposure_contract.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+COMPOSE = ROOT / "src" / "docker-compose.yml"
+CHECKLIST = ROOT / "docs" / "NETWORK_SECURITY_VLAN_CREDENTIALS_CHECKLIST.md"
+
+
+def test_frigate_ports_are_loopback_only():
+    content = COMPOSE.read_text(encoding="utf-8")
+
+    assert "127.0.0.1:8554:8554" in content
+    assert "127.0.0.1:8555:8555" in content
+    assert "127.0.0.1:8555:8555/udp" in content
+    assert "- \"8554:8554\"" not in content
+    assert "- \"8555:8555\"" not in content
+
+
+def test_network_checklist_mentions_frigate_loopback_binding():
+    content = CHECKLIST.read_text(encoding="utf-8")
+
+    assert "Frigate (8554/8555) restrito a loopback" in content


### PR DESCRIPTION
## Summary
- restrict Frigate RTSP/WebRTC published ports to loopback (`127.0.0.1`)
- add contract test to prevent accidental public port binding regressions
- update network security checklist with explicit Frigate loopback control

## Validation
- `pytest -q tests/backend/test_frigate_port_exposure_contract.py tests/backend/test_network_security_compliance_contract.py`

Closes #152
