### PR TITLE
[RedTeam] RT-02 - Token de WebSocket em query string

### DIFF
--- a/docs/API_DOCS.md
+++ b/docs/API_DOCS.md
@@ -279,8 +279,10 @@ curl -H "X-API-Key: ${DASHBOARD_API_KEY}" \
 
 **Exemplo WebSocket:**
 
-```text
-ws://localhost:8000/ws?api_key=${DASHBOARD_API_KEY}
+```bash
+websocat \
+  -H "X-API-Key: ${DASHBOARD_API_KEY}" \
+  ws://localhost:8000/ws
 ```
 
 ---

--- a/src/dashboard/backend/app/security.py
+++ b/src/dashboard/backend/app/security.py
@@ -38,11 +38,7 @@ async def require_api_key(
 
 async def require_ws_api_key(websocket: WebSocket) -> None:
     expected = _configured_api_key()
-    token = (
-        websocket.headers.get("x-api-key")
-        or websocket.query_params.get("api_key")
-        or websocket.query_params.get("token")
-    )
+    token = websocket.headers.get("x-api-key")
     auth = websocket.headers.get("authorization", "")
     if not token and auth.lower().startswith("bearer "):
         token = auth.split(" ", 1)[1].strip()

--- a/tests/backend/test_dashboard_api.py
+++ b/tests/backend/test_dashboard_api.py
@@ -169,9 +169,18 @@ def test_ws_with_api_key(monkeypatch):
     app = _build_test_app()
     client = TestClient(app)
 
-    with client.websocket_connect("/ws?api_key=test-api-key") as ws_conn:
+    with client.websocket_connect("/ws", headers={"X-API-Key": "test-api-key"}) as ws_conn:
         payload = json.loads(ws_conn.receive_text())
         assert payload["type"] == "initial_state"
         assert "states" in payload
 
     assert subscribed == []
+
+
+def test_ws_rejects_api_key_in_query_string():
+    app = _build_test_app()
+    client = TestClient(app)
+
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect("/ws?api_key=test-api-key"):
+            pass

--- a/tests/backend/test_ws_auth_contract.py
+++ b/tests/backend/test_ws_auth_contract.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SECURITY = ROOT / "src" / "dashboard" / "backend" / "app" / "security.py"
+
+
+def test_ws_auth_does_not_accept_query_params():
+    content = SECURITY.read_text(encoding="utf-8")
+
+    assert 'websocket.headers.get("x-api-key")' in content
+    assert "query_params.get(\"api_key\")" not in content
+    assert "query_params.get(\"token\")" not in content


### PR DESCRIPTION
## Summary
- remove WebSocket API key acceptance from query string
- keep WebSocket auth only via headers (`X-API-Key` or `Authorization: Bearer`)
- update backend tests and add source-level contract test
- update API docs WebSocket auth example

## Validation
- `pytest -q tests/backend/test_ws_auth_contract.py`
- `pytest -q tests/backend/test_dashboard_api.py` (não executado neste ambiente por ausência de `fastapi`)

Closes #153
