### PR TITLE
[RedTeam] RT-03 - Ausência de rate limit na autenticação API/WS

### DIFF
--- a/docs/API_DOCS.md
+++ b/docs/API_DOCS.md
@@ -256,6 +256,7 @@ Usada para atualizacoes em tempo real no dashboard. Permite subscribe a mudancas
 **Autenticacao**:
 - `X-API-Key: <DASHBOARD_API_KEY>`
 - ou `Authorization: Bearer <DASHBOARD_API_KEY>`
+- Proteção anti-bruteforce: tentativas inválidas são rate-limited por IP (HTTP e WS).
 
 | Metodo | Endpoint | Descricao |
 |--------|----------|-----------|

--- a/src/dashboard/backend/app/security.py
+++ b/src/dashboard/backend/app/security.py
@@ -1,12 +1,21 @@
 import secrets
+import time
+from collections import defaultdict, deque
+from collections.abc import MutableMapping
 
-from fastapi import HTTPException, Security, WebSocket, WebSocketException, status
+from fastapi import HTTPException, Request, Security, WebSocket, WebSocketException, status
 from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
 
 from app.config import settings
 
 _api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 _bearer_scheme = HTTPBearer(auto_error=False)
+_api_auth_failures: MutableMapping[str, deque[float]] = defaultdict(deque)
+_ws_auth_attempts: MutableMapping[str, deque[float]] = defaultdict(deque)
+_AUTH_WINDOW_SECONDS = 60
+_AUTH_MAX_FAILURES_PER_WINDOW = 20
+_WS_AUTH_WINDOW_SECONDS = 60
+_WS_AUTH_MAX_ATTEMPTS_PER_WINDOW = 60
 
 
 def _configured_api_key() -> str:
@@ -25,7 +34,28 @@ def _is_valid_api_key(candidate: str | None, expected: str) -> bool:
     return secrets.compare_digest(candidate, expected)
 
 
+def _client_ip(value: str | None) -> str:
+    return (value or "unknown").strip() or "unknown"
+
+
+def _register_rate_event(
+    store: MutableMapping[str, deque[float]],
+    key: str,
+    *,
+    now: float,
+    window_seconds: int,
+    max_events: int,
+) -> bool:
+    queue = store[key]
+    cutoff = now - window_seconds
+    while queue and queue[0] < cutoff:
+        queue.popleft()
+    queue.append(now)
+    return len(queue) <= max_events
+
+
 async def require_api_key(
+    request: Request,
     x_api_key: str | None = Security(_api_key_header),
     credentials: HTTPAuthorizationCredentials | None = Security(_bearer_scheme),
 ) -> None:
@@ -33,10 +63,30 @@ async def require_api_key(
     bearer_key = credentials.credentials if credentials else None
     if _is_valid_api_key(x_api_key, expected) or _is_valid_api_key(bearer_key, expected):
         return
+    ip = _client_ip(request.client.host if request.client else None)
+    if not _register_rate_event(
+        _api_auth_failures,
+        ip,
+        now=time.time(),
+        window_seconds=_AUTH_WINDOW_SECONDS,
+        max_events=_AUTH_MAX_FAILURES_PER_WINDOW,
+    ):
+        raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Too many auth failures.")
     raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid API key.")
 
 
 async def require_ws_api_key(websocket: WebSocket) -> None:
+    ip = _client_ip(websocket.client.host if websocket.client else None)
+    if not _register_rate_event(
+        _ws_auth_attempts,
+        ip,
+        now=time.time(),
+        window_seconds=_WS_AUTH_WINDOW_SECONDS,
+        max_events=_WS_AUTH_MAX_ATTEMPTS_PER_WINDOW,
+    ):
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION, reason="Too many auth attempts.")
+
     expected = _configured_api_key()
     token = websocket.headers.get("x-api-key")
     auth = websocket.headers.get("authorization", "")

--- a/tests/backend/test_auth_rate_limit_contract.py
+++ b/tests/backend/test_auth_rate_limit_contract.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SECURITY = ROOT / "src" / "dashboard" / "backend" / "app" / "security.py"
+
+
+def test_security_module_has_auth_rate_limit_controls():
+    content = SECURITY.read_text(encoding="utf-8")
+
+    assert "_api_auth_failures" in content
+    assert "_ws_auth_attempts" in content
+    assert "_AUTH_MAX_FAILURES_PER_WINDOW" in content
+    assert "_WS_AUTH_MAX_ATTEMPTS_PER_WINDOW" in content
+    assert "HTTP_429_TOO_MANY_REQUESTS" in content
+    assert "Too many auth failures." in content


### PR DESCRIPTION
## Summary
- add per-IP auth throttling for HTTP API key failures (429 after threshold)
- add per-IP WebSocket auth-attempt throttling
- add contract test for auth rate-limit controls
- document anti-bruteforce behavior in API docs

## Validation
- `pytest -q tests/backend/test_auth_rate_limit_contract.py tests/backend/test_ws_auth_contract.py`

Closes #154
