### PR TITLE
[RedTeam] RT-06 - Log forense do módulo de defesa em /tmp

### DIFF
--- a/docs/DRONE_DEFENSE_IMPLEMENTATION.md
+++ b/docs/DRONE_DEFENSE_IMPLEMENTATION.md
@@ -46,6 +46,7 @@ Interface de configuracao:
 - `DEFENSE_MAX_TRIGGERS_PER_DAY_UGV`
 - `DEFENSE_EXCLUSION_ZONES_UGV`
 - `DEFENSE_AUDIT_LOG_PATH_UGV`
+  - recomendado: caminho persistente fora de `/tmp` (ex.: `/var/lib/home-security/audit/ugv_defense_audit.log`)
 
 ## Consulta juridica (registro minimo obrigatorio)
 

--- a/src/.env.example
+++ b/src/.env.example
@@ -78,7 +78,7 @@ DEFENSE_WARNING_SECONDS_UGV=5
 DEFENSE_COOLDOWN_SECONDS_UGV=30
 DEFENSE_MAX_TRIGGERS_PER_DAY_UGV=3
 DEFENSE_EXCLUSION_ZONES_UGV=sidewalk,service_entry,neighbor_gate
-DEFENSE_AUDIT_LOG_PATH_UGV=/tmp/ugv_defense_audit.log
+DEFENSE_AUDIT_LOG_PATH_UGV=/var/lib/home-security/audit/ugv_defense_audit.log
 DEFENSE_ACTUATOR_SPEC_UGV=solenoid_12v_nc+co2_valve
 
 # --- Drones: Autorização de comando MQTT ---

--- a/src/drones/common/defense_controller.py
+++ b/src/drones/common/defense_controller.py
@@ -3,6 +3,7 @@ import hashlib
 import hmac
 import json
 import logging
+import os
 import struct
 import time
 from pathlib import Path
@@ -30,7 +31,7 @@ class DefenseController:
         cooldown_seconds=30,
         max_triggers_per_day=3,
         exclusion_zones=None,
-        audit_log_path="/tmp/ugv_defense_audit.log",
+        audit_log_path="/var/lib/home-security/audit/ugv_defense_audit.log",
     ):
         if not pin_code:
             raise ValueError("DefenseController requires a non-empty pin_code.")
@@ -90,6 +91,7 @@ class DefenseController:
             self.audit_log_path.parent.mkdir(parents=True, exist_ok=True)
             with self.audit_log_path.open("a", encoding="utf-8") as fp:
                 fp.write(json.dumps(entry, ensure_ascii=True) + "\n")
+            os.chmod(self.audit_log_path, 0o600)
             self.audit_head = digest
         except Exception as exc:
             logging.error("Audit log write failed: %s", exc)

--- a/src/drones/ugv/app/ugv_control.py
+++ b/src/drones/ugv/app/ugv_control.py
@@ -79,7 +79,7 @@ DEFENSE_EXCLUSION_ZONES = {
     if z.strip()
 }
 DEFENSE_AUDIT_LOG_PATH = os.environ.get(
-    "DEFENSE_AUDIT_LOG_PATH_UGV", "/tmp/ugv_defense_audit.log"
+    "DEFENSE_AUDIT_LOG_PATH_UGV", "/var/lib/home-security/audit/ugv_defense_audit.log"
 ).strip()
 DEFENSE_ACTUATOR_SPEC = os.environ.get(
     "DEFENSE_ACTUATOR_SPEC_UGV", "solenoid_12v_nc+co2_valve"

--- a/tests/backend/test_defense_audit_log_path_contract.py
+++ b/tests/backend/test_defense_audit_log_path_contract.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFENSE_CONTROLLER = ROOT / "src" / "drones" / "common" / "defense_controller.py"
+UGV_CONTROL = ROOT / "src" / "drones" / "ugv" / "app" / "ugv_control.py"
+ENV_EXAMPLE = ROOT / "src" / ".env.example"
+
+
+def test_defense_audit_default_path_is_not_tmp():
+    controller = DEFENSE_CONTROLLER.read_text(encoding="utf-8")
+    ugv = UGV_CONTROL.read_text(encoding="utf-8")
+    env_example = ENV_EXAMPLE.read_text(encoding="utf-8")
+
+    assert "/var/lib/home-security/audit/ugv_defense_audit.log" in controller
+    assert "/var/lib/home-security/audit/ugv_defense_audit.log" in ugv
+    assert "DEFENSE_AUDIT_LOG_PATH_UGV=/var/lib/home-security/audit/ugv_defense_audit.log" in env_example
+    assert "/tmp/ugv_defense_audit.log" not in controller
+
+
+def test_defense_audit_log_permission_is_restricted():
+    controller = DEFENSE_CONTROLLER.read_text(encoding="utf-8")
+
+    assert "os.chmod(self.audit_log_path, 0o600)" in controller


### PR DESCRIPTION
## Summary
- move default defense audit log path from `/tmp` to persistent path under `/var/lib/home-security/audit/`
- enforce restrictive permissions (`0600`) on audit file writes
- update `.env.example` and defense implementation docs
- add contract test for secure path and permissions

## Validation
- `pytest -q tests/backend/test_defense_audit_log_path_contract.py tests/backend/test_defense_controller.py`

Closes #157
