### PR TITLE
[RedTeam] RT-07 - Hardening insuficiente em manifests Kubernetes

### DIFF
--- a/k8s/base/dashboard/dashboard.yaml
+++ b/k8s/base/dashboard/dashboard.yaml
@@ -60,6 +60,9 @@ spec:
         app.kubernetes.io/name: dashboard
         app.kubernetes.io/component: api
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: dashboard-api
           image: home-security-dashboard-api:latest
@@ -108,6 +111,16 @@ spec:
                 configMapKeyRef:
                   name: dashboard-config
                   key: TZ
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           livenessProbe:
             httpGet:
               path: /health
@@ -127,6 +140,9 @@ spec:
             limits:
               cpu: "500m"
               memory: "512Mi"
+      volumes:
+        - name: tmp
+          emptyDir: {}
 
 ---
 # --- Service: API ---
@@ -170,6 +186,9 @@ spec:
         app.kubernetes.io/name: dashboard
         app.kubernetes.io/component: frontend
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: dashboard-frontend
           image: home-security-dashboard-frontend:latest
@@ -177,6 +196,16 @@ spec:
           ports:
             - containerPort: 8080
               name: http
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           livenessProbe:
             httpGet:
               path: /
@@ -196,6 +225,9 @@ spec:
             limits:
               cpu: "200m"
               memory: "128Mi"
+      volumes:
+        - name: tmp
+          emptyDir: {}
 
 ---
 # --- Service: Frontend ---

--- a/k8s/base/mosquitto/mosquitto.yaml
+++ b/k8s/base/mosquitto/mosquitto.yaml
@@ -122,6 +122,9 @@ spec:
         app.kubernetes.io/component: mqtt-broker
         app.kubernetes.io/part-of: home-security
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: mosquitto
           image: eclipse-mosquitto:2.0.20
@@ -143,9 +146,20 @@ spec:
               readOnly: true
             - name: data
               mountPath: /mosquitto/data
+            - name: tmp
+              mountPath: /tmp
           env:
             - name: TZ
               value: America/Sao_Paulo
+          securityContext:
+            runAsUser: 1883
+            runAsGroup: 1883
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           resources:
             requests:
               cpu: 50m
@@ -170,6 +184,8 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: mosquitto-data
+        - name: tmp
+          emptyDir: {}
 
 ---
 # --- Service ---

--- a/tests/backend/test_k8s_security_context_contract.py
+++ b/tests/backend/test_k8s_security_context_contract.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DASHBOARD_K8S = ROOT / "k8s" / "base" / "dashboard" / "dashboard.yaml"
+MOSQUITTO_K8S = ROOT / "k8s" / "base" / "mosquitto" / "mosquitto.yaml"
+
+
+def test_dashboard_manifests_include_baseline_container_hardening():
+    content = DASHBOARD_K8S.read_text(encoding="utf-8")
+
+    assert "runAsNonRoot: true" in content
+    assert "allowPrivilegeEscalation: false" in content
+    assert "readOnlyRootFilesystem: true" in content
+    assert "seccompProfile:" in content
+    assert "type: RuntimeDefault" in content
+    assert "drop:" in content
+    assert "- ALL" in content
+
+
+def test_mosquitto_manifest_includes_baseline_container_hardening():
+    content = MOSQUITTO_K8S.read_text(encoding="utf-8")
+
+    assert "runAsUser: 1883" in content
+    assert "runAsNonRoot: true" in content
+    assert "allowPrivilegeEscalation: false" in content
+    assert "readOnlyRootFilesystem: true" in content
+    assert "seccompProfile:" in content
+    assert "type: RuntimeDefault" in content


### PR DESCRIPTION
## Summary
- add baseline pod/container hardening to dashboard API/frontend deployments
- add baseline pod/container hardening to mosquitto deployment
- enforce seccomp runtime default, no privilege escalation, dropped caps and read-only root filesystem
- add contract tests for hardening controls in critical manifests

## Validation
- `pytest -q tests/backend/test_k8s_security_context_contract.py tests/backend/test_network_security_compliance_contract.py`

Closes #158
