### PR TITLE
[RedTeam] RT-08 - MQTT sem TLS obrigatório em produção

### DIFF
--- a/docs/NETWORK_SECURITY_VLAN_CREDENTIALS_CHECKLIST.md
+++ b/docs/NETWORK_SECURITY_VLAN_CREDENTIALS_CHECKLIST.md
@@ -31,7 +31,9 @@ Evidência técnica esperada: export de regras do firewall/switch.
   Evidência: `src/mosquitto/config/acl_file`
 - [x] `allow_anonymous false` configurado.
   Evidência: `src/mosquitto/config/mosquitto.conf`
-- [ ] TLS MQTT ativo em produção (porta 8883 com certificados válidos).
+- [x] Perfil de produção TLS-only versionado (`mosquitto.prod.conf`).
+  Evidência: `src/mosquitto/config/mosquitto.prod.conf`
+- [ ] TLS MQTT ativo em produção (porta 8883 com certificados válidos e certificado instalado).
 - [ ] Porta 1883 não exposta externamente.
 
 ## 4. Gestão de credenciais

--- a/scripts/network_security_audit.sh
+++ b/scripts/network_security_audit.sh
@@ -39,6 +39,26 @@ else
   emit "Script de certificados MQTT" "FAIL" "Script ausente ou não executável"
 fi
 
+if [ -f src/mosquitto/config/mosquitto.prod.conf ]; then
+  emit "Perfil TLS-only de produção do Mosquitto" "PASS" "src/mosquitto/config/mosquitto.prod.conf presente"
+else
+  emit "Perfil TLS-only de produção do Mosquitto" "FAIL" "mosquitto.prod.conf ausente"
+fi
+
+if [ "${APP_ENV:-}" = "production" ]; then
+  if grep -q '^listener 8883' src/mosquitto/config/mosquitto.prod.conf; then
+    emit "MQTT TLS em produção (listener 8883)" "PASS" "listener 8883 encontrado"
+  else
+    emit "MQTT TLS em produção (listener 8883)" "FAIL" "listener 8883 não encontrado"
+  fi
+
+  if grep -q '^listener 1883' src/mosquitto/config/mosquitto.prod.conf; then
+    emit "MQTT sem listener plaintext em produção" "FAIL" "listener 1883 presente em mosquitto.prod.conf"
+  else
+    emit "MQTT sem listener plaintext em produção" "PASS" "listener 1883 ausente em mosquitto.prod.conf"
+  fi
+fi
+
 if grep -q '^permit_join:\s*false' src/zigbee2mqtt/configuration.yaml; then
   emit "Zigbee2MQTT com pareamento fechado por padrão" "PASS" "permit_join: false"
 else

--- a/src/docs/QUICK_START.md
+++ b/src/docs/QUICK_START.md
@@ -144,14 +144,19 @@ No HACS, instale:
 |-------|---------|-----------|
 | 8123 | Home Assistant | HTTP |
 | 1883 | Mosquitto MQTT | TCP (loopback) |
+| 8883 | Mosquitto MQTT (produção) | TLS |
 | 9001 | Mosquitto WebSocket | TCP (loopback) |
 | 8080 | Zigbee2MQTT Frontend | HTTP (loopback) |
 | 5000 | Frigate Web UI | HTTP (loopback) |
-| 8554 | Frigate RTSP Restream | TCP |
-| 8555 | Frigate WebRTC | TCP/UDP |
+| 8554 | Frigate RTSP Restream | TCP (loopback) |
+| 8555 | Frigate WebRTC | TCP/UDP (loopback) |
 
 > Nota: Dashboard API roda com `uvicorn --workers 1` por restrição arquitetural atual
 > do cliente Home Assistant (`ha_client.py` usa estado em memória por processo).
+
+## Produção: baseline MQTT TLS-only
+
+Para produção, use `src/mosquitto/config/mosquitto.prod.conf` (listener 8883, sem 1883).
 
 ---
 

--- a/src/mosquitto/config/mosquitto.conf
+++ b/src/mosquitto/config/mosquitto.conf
@@ -36,6 +36,9 @@ log_timestamp true
 log_timestamp_format %Y-%m-%dT%H:%M:%S
 
 # --- TLS (optional but recommended for external access) ---
+# Production baseline disponível em:
+#   /mosquitto/config/mosquitto.prod.conf
+# (TLS-only em 8883, sem listener plaintext 1883)
 # Uncomment and configure after running scripts/generate-mqtt-certs.sh
 # To enable TLS, replace the plain listener 1883 above with the block below:
 #

--- a/src/mosquitto/config/mosquitto.prod.conf
+++ b/src/mosquitto/config/mosquitto.prod.conf
@@ -1,0 +1,41 @@
+# =============================================================================
+# Mosquitto MQTT Broker Configuration (Production TLS-only)
+# Home Security DIY
+# =============================================================================
+
+# --- TLS listener only (production baseline) ---
+listener 8883
+protocol mqtt
+
+cafile /mosquitto/certs/ca.crt
+certfile /mosquitto/certs/server.crt
+keyfile /mosquitto/certs/server.key
+tls_version tlsv1.2
+require_certificate false
+
+# Optional WebSocket endpoint (must stay internal or behind authenticated proxy)
+listener 9001
+protocol websockets
+
+# --- Authentication ---
+allow_anonymous false
+password_file /mosquitto/config/password_file
+acl_file /mosquitto/config/acl_file
+
+# --- Persistence ---
+persistence true
+persistence_location /mosquitto/data/
+
+# --- Logging ---
+log_dest stdout
+log_type error
+log_type warning
+log_type notice
+log_timestamp true
+log_timestamp_format %Y-%m-%dT%H:%M:%S
+
+# --- Security ---
+max_inflight_messages 20
+max_queued_messages 1000
+message_size_limit 262144
+connection_messages true

--- a/tests/backend/test_mqtt_tls_production_contract.py
+++ b/tests/backend/test_mqtt_tls_production_contract.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PROD_CONF = ROOT / "src" / "mosquitto" / "config" / "mosquitto.prod.conf"
+AUDIT_SCRIPT = ROOT / "scripts" / "network_security_audit.sh"
+CHECKLIST = ROOT / "docs" / "NETWORK_SECURITY_VLAN_CREDENTIALS_CHECKLIST.md"
+
+
+def test_mosquitto_production_profile_is_tls_only():
+    content = PROD_CONF.read_text(encoding="utf-8")
+
+    assert "listener 8883" in content
+    assert "cafile /mosquitto/certs/ca.crt" in content
+    assert "certfile /mosquitto/certs/server.crt" in content
+    assert "keyfile /mosquitto/certs/server.key" in content
+    assert "listener 1883" not in content
+
+
+def test_network_audit_checks_production_tls_baseline():
+    content = AUDIT_SCRIPT.read_text(encoding="utf-8")
+
+    assert "mosquitto.prod.conf" in content
+    assert 'if [ "${APP_ENV:-}" = "production" ]; then' in content
+    assert "listener 8883" in content
+
+
+def test_network_checklist_mentions_tls_only_profile():
+    content = CHECKLIST.read_text(encoding="utf-8")
+
+    assert "Perfil de produção TLS-only versionado" in content


### PR DESCRIPTION
## Summary
- add `mosquitto.prod.conf` with TLS-only production baseline (listener 8883, no 1883)
- update network security audit script to enforce TLS-only checks when `APP_ENV=production`
- update network checklist and quick start docs with production MQTT TLS baseline
- add contract tests for production TLS profile and audit enforcement

## Validation
- `pytest -q tests/backend/test_mqtt_tls_production_contract.py tests/backend/test_network_security_compliance_contract.py`
- `APP_ENV=production bash scripts/network_security_audit.sh`

Closes #159
