### PR TITLE
fix(k8s): harden zigbee2mqtt workload and remove privileged mode

### DIFF
--- a/k8s/base/zigbee2mqtt/zigbee2mqtt.yaml
+++ b/k8s/base/zigbee2mqtt/zigbee2mqtt.yaml
@@ -90,6 +90,9 @@ spec:
         app.kubernetes.io/component: zigbee-bridge
         app.kubernetes.io/part-of: home-security
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: zigbee2mqtt
           image: koenkk/zigbee2mqtt:latest
@@ -105,6 +108,8 @@ spec:
               subPath: configuration.yaml
             - name: zigbee-device
               mountPath: /dev/ttyACM0
+            - name: tmp
+              mountPath: /tmp
           env:
             - name: TZ
               value: America/Sao_Paulo
@@ -126,7 +131,14 @@ spec:
               cpu: 500m
               memory: 256Mi
           securityContext:
-            privileged: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           livenessProbe:
             httpGet:
               path: /
@@ -150,6 +162,8 @@ spec:
           hostPath:
             path: /dev/ttyUSB0
             type: CharDevice
+        - name: tmp
+          emptyDir: {}
       # Schedule on node with Zigbee USB dongle
       nodeSelector:
         home-security/zigbee-coordinator: "true"

--- a/tests/backend/test_k8s_security_context_contract.py
+++ b/tests/backend/test_k8s_security_context_contract.py
@@ -4,6 +4,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 DASHBOARD_K8S = ROOT / "k8s" / "base" / "dashboard" / "dashboard.yaml"
 MOSQUITTO_K8S = ROOT / "k8s" / "base" / "mosquitto" / "mosquitto.yaml"
+Z2M_K8S = ROOT / "k8s" / "base" / "zigbee2mqtt" / "zigbee2mqtt.yaml"
 
 
 def test_dashboard_manifests_include_baseline_container_hardening():
@@ -27,3 +28,16 @@ def test_mosquitto_manifest_includes_baseline_container_hardening():
     assert "readOnlyRootFilesystem: true" in content
     assert "seccompProfile:" in content
     assert "type: RuntimeDefault" in content
+
+
+def test_zigbee2mqtt_manifest_drops_privileged_and_has_baseline_hardening():
+    content = Z2M_K8S.read_text(encoding="utf-8")
+
+    assert "privileged: true" not in content
+    assert "runAsNonRoot: true" in content
+    assert "allowPrivilegeEscalation: false" in content
+    assert "readOnlyRootFilesystem: true" in content
+    assert "seccompProfile:" in content
+    assert "type: RuntimeDefault" in content
+    assert "drop:" in content
+    assert "- ALL" in content


### PR DESCRIPTION
## Resumo
Resolve RT-09 removendo modo privilegiado do Zigbee2MQTT no Kubernetes e aplicando baseline de hardening.

Closes #168

## Mudancas
- remove `privileged: true` em `k8s/base/zigbee2mqtt/zigbee2mqtt.yaml`
- adiciona hardening no pod/container:
  - `seccompProfile.type: RuntimeDefault`
  - `runAsUser: 1000`, `runAsGroup: 1000`, `runAsNonRoot: true`
  - `allowPrivilegeEscalation: false`
  - `readOnlyRootFilesystem: true`
  - `capabilities.drop: [ALL]`
- adiciona `emptyDir` em `/tmp` para manter FS raiz somente leitura
- expande teste de contrato para validar Zigbee2MQTT

## Validacao
- `pytest -q tests/backend/test_k8s_security_context_contract.py` -> 3 passed
- `bash scripts/network_security_audit.sh` -> sem regressao (PASS nos checks automatizados)
