### PR TITLE
fix(test): stabilize backend suite and sync docs/wiki coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,9 +76,9 @@ Siga o guia [src/docs/QUICK_START.md](src/docs/QUICK_START.md) para configurar s
 ### Rodando testes do Dashboard Backend
 
 ```bash
-cd src/dashboard/backend
-python -m pip install -r requirements.txt pytest
-pytest ../../../tests/backend -q
+python3 -m venv .venv
+.venv/bin/pip install -r src/dashboard/backend/requirements.txt pytest pytest-cov
+.venv/bin/pytest -q tests/backend
 ```
 
 ### Cobertura mínima (CI)

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -85,6 +85,14 @@ docker compose up -d
 ./scripts/validate-configs.sh
 ```
 
+### 3.5 Executar testes automatizados backend (recomendado)
+
+```bash
+python3 -m venv .venv
+.venv/bin/pip install -r src/dashboard/backend/requirements.txt pytest pytest-cov
+.venv/bin/pytest -q tests/backend
+```
+
 ---
 
 ## 4. Como contribuir

--- a/src/dashboard/backend/app/routers/alerts.py
+++ b/src/dashboard/backend/app/routers/alerts.py
@@ -1,5 +1,6 @@
 import json
 from datetime import datetime
+from typing import ClassVar
 
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, field_validator
@@ -58,7 +59,7 @@ async def list_device_positions(db: AsyncSession = Depends(get_db)) -> list[dict
 
 
 class MapConfigPayload(BaseModel):
-    MAX_FLOORPLAN_DATA_URL_LENGTH = 2_000_000
+    MAX_FLOORPLAN_DATA_URL_LENGTH: ClassVar[int] = 2_000_000
     floorplan_image_data_url: str | None = None
     geo_bounds: dict[str, float] | None = None
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -50,6 +50,8 @@ O projeto combina automação, vídeo inteligente, sensores e drones para segura
 - Validação automática de links Markdown no CI (`docs-links`).
 - Compliance operacional (LGPD, UAV, defesa, hardening físico, rede, integração e Matter/Thread) com runbooks e templates versionados.
 - Pipeline dedicado `compliance-gates.yml` com artifacts e bloqueio de merge para não conformidades estruturais.
+- Hardening de Kubernetes no Zigbee2MQTT com remoção de `privileged: true` e baseline de segurança de container.
+- Suíte backend executada integralmente em ambiente reprodutível com `.venv` (`79 testes passando` em 2026-02-22).
 
 ## Documentação no repositório
 

--- a/wiki/Testes-e-Validacao.md
+++ b/wiki/Testes-e-Validacao.md
@@ -190,6 +190,25 @@ Execute após cada deploy em ambiente real:
 Ver `.github/workflows/validate.yml` para implementação completa.
 Ver `.github/workflows/compliance-gates.yml` para o gate de compliance.
 
+## Status Atual de Cobertura Automatizada
+
+Data de referência: **2026-02-22**
+
+Execução local validada:
+
+```bash
+python3 -m venv .venv
+.venv/bin/pip install -r src/dashboard/backend/requirements.txt pytest pytest-cov
+.venv/bin/pytest -q tests/backend
+```
+
+Resultado mais recente:
+- `79 passed in 0.61s`
+
+Notas:
+- Esta cobertura refere-se à suíte automatizada do diretório `tests/backend`.
+- Itens de validação física e operacional de campo continuam com evidência manual (checklists/runbooks).
+
 ### Cobertura de compliance operacional
 
 O gate de compliance inclui também contratos de documentação operacional:


### PR DESCRIPTION
## Resumo
Fecha gaps de cobertura automatizada e sincronizacao de documentacao/wiki.

Closes #170

## O que foi feito
- Corrigido bug de compatibilidade com Pydantic v2 em `MapConfigPayload` (`ClassVar` em constante interna).
- Reescritos testes de `tests/backend/test_dashboard_api.py` para `httpx.AsyncClient + ASGITransport`, removendo travamento do `TestClient` neste ambiente.
- Atualizado guia de contribuicao com fluxo reprodutivel via `.venv` para testes backend.
- Atualizado onboarding com passo de execucao de testes automatizados backend.
- Atualizada wiki local com status de cobertura automatizada e comandos de execucao.
- Publicada wiki no GitHub Wiki via `scripts/publish_wiki.sh`.

## Validacao
- `.venv/bin/pytest -q tests/backend` -> `79 passed`
- `bash scripts/compliance_checklist_audit.sh`
- `bash scripts/network_security_audit.sh`
- `bash scripts/physical_hardening_audit.sh`
- `bash scripts/publish_wiki.sh rodrigobprado/Home-Security-DIY https` -> wiki publicada com sucesso
