### PR TITLE
docs/k8s: consolidar validacao do cluster e atualizar wiki

### DIFF
--- a/docs/INTEGRATION_SMOKE_PRODUCTION_RUNBOOK.md
+++ b/docs/INTEGRATION_SMOKE_PRODUCTION_RUNBOOK.md
@@ -25,3 +25,27 @@ Padronizar execucao do smoke test no ambiente ativo com evidencias operacionais.
 ## Frequencia
 - Executar apos cada release.
 - Executar apos mudancas relevantes em HA, Dashboard, Frigate ou rede.
+
+## Ultima execucao registrada (ambiente K3s de validacao)
+
+Data: 2026-02-22
+
+Estado dos workloads (`kubectl -n home-security get pods`):
+- dashboard-api: `1/1 Running`
+- dashboard-frontend: `1/1 Running`
+- homeassistant: `1/1 Running`
+- mosquitto: `1/1 Running`
+- postgres: `1/1 Running`
+- frigate: `1/1 Running`
+- zigbee2mqtt: `1/1 Running`
+
+Validacao HTTP via ingress TLS:
+- `https://homeassistant-home-security.toca.lan` -> `302`
+- `https://dashboard-home-security.toca.lan` -> `200`
+- `https://frigate-home-security.toca.lan` -> `200`
+- `https://zigbee2mqtt-home-security.toca.lan` -> `200`
+
+Observacao operacional:
+- No ambiente de validacao sem hardware fisico (cameras/USB Zigbee),
+  `frigate` e `zigbee2mqtt` podem operar em modo stub para manter
+  disponibilidade de pods/ingress e viabilizar os testes de plataforma.

--- a/k8s/base/zigbee2mqtt/zigbee2mqtt.yaml
+++ b/k8s/base/zigbee2mqtt/zigbee2mqtt.yaml
@@ -100,15 +100,18 @@ spec:
             - sh
             - -lc
             - |
-              mkdir -p /www
-              cat > /www/index.html <<'EOF'
+              mkdir -p /tmp/www
+              cat > /tmp/www/index.html <<'EOF'
               <html><body><h1>Zigbee2MQTT</h1><p>Stub mode (no USB adapter detected).</p></body></html>
               EOF
-              httpd -f -p 8080 -h /www
+              httpd -f -p 8080 -h /tmp/www
           ports:
             - name: frontend
               containerPort: 8080
               protocol: TCP
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           resources:
             requests:
               cpu: 20m
@@ -117,11 +120,11 @@ spec:
               cpu: 100m
               memory: 64Mi
           securityContext:
-            runAsUser: 0
-            runAsGroup: 0
-            runAsNonRoot: false
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - ALL
@@ -135,6 +138,9 @@ spec:
               port: frontend
             initialDelaySeconds: 5
             periodSeconds: 10
+      volumes:
+        - name: tmp
+          emptyDir: {}
 
 ---
 # --- Service ---

--- a/wiki/Operacao-e-Manutencao.md
+++ b/wiki/Operacao-e-Manutencao.md
@@ -90,3 +90,17 @@ docker compose logs -f homeassistant
 # Ver conexão WebSocket ativa
 curl http://localhost:8000/api/services/status
 ```
+
+## Perfil de validação em K3s (toca.lan)
+
+Hosts de acesso via ingress:
+
+- `https://homeassistant-home-security.toca.lan`
+- `https://dashboard-home-security.toca.lan`
+- `https://frigate-home-security.toca.lan`
+- `https://zigbee2mqtt-home-security.toca.lan`
+
+Notas para laboratório:
+
+- Sem hardware físico (dongle Zigbee/câmeras), os serviços `zigbee2mqtt` e `frigate` podem operar em modo *stub* para manter o cluster `Ready`.
+- Antes de promover para produção física, reverter para os manifests com integração real de câmera e coordenador Zigbee.

--- a/wiki/Testes-e-Validacao.md
+++ b/wiki/Testes-e-Validacao.md
@@ -203,7 +203,7 @@ python3 -m venv .venv
 ```
 
 Resultado mais recente:
-- `79 passed in 0.61s`
+- `82 passed in 0.67s`
 
 Notas:
 - Esta cobertura refere-se à suíte automatizada do diretório `tests/backend`.


### PR DESCRIPTION
## Resumo\n- atualiza runbook de smoke com a execucao mais recente no K3s\n- atualiza wiki (testes e operacao) com status e endpoints \n- ajusta  para perfil de validacao compativel com os contratos de seguranca\n\n## Testes\n- .venv/bin/pytest -q\n- resultado: 82 passed\n\n## Observacoes\n- altera somente manifests/docs/wiki; sem mudancas de codigo de negocio