### PR TITLE
k8s/docs: persistencia de dados criticos em manifests

### DIFF
--- a/docs/INTEGRATION_SMOKE_PRODUCTION_RUNBOOK.md
+++ b/docs/INTEGRATION_SMOKE_PRODUCTION_RUNBOOK.md
@@ -1,7 +1,7 @@
 # Runbook de Smoke de Integracao em Ambiente Real
 
 Issue: #141  
-Ultima atualizacao: 2026-02-22
+Ultima atualizacao: 2026-02-23
 
 ## Objetivo
 Padronizar execucao do smoke test no ambiente ativo com evidencias operacionais.
@@ -49,3 +49,7 @@ Observacao operacional:
 - No ambiente de validacao sem hardware fisico (cameras/USB Zigbee),
   `frigate` e `zigbee2mqtt` podem operar em modo stub para manter
   disponibilidade de pods/ingress e viabilizar os testes de plataforma.
+- Mesmo em modo stub, os manifests mantem persistencia dos dados criticos
+  de plataforma via PVCs:
+  `mosquitto-data`, `homeassistant-config`, `zigbee2mqtt-data`,
+  `frigate-config`, `frigate-media` e `postgres-data`.

--- a/k8s/base/frigate/frigate.yaml
+++ b/k8s/base/frigate/frigate.yaml
@@ -215,6 +215,24 @@ stringData:
   FRIGATE_CAM_GARAGEM_SUB_URL: "rtsp://CHANGE_ME_user:CHANGE_ME_password@CHANGE_ME_IP_4:554/h264Preview_01_sub"
 
 ---
+# --- PersistentVolumeClaim (config + events DB) ---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: frigate-config
+  namespace: home-security
+  labels:
+    app.kubernetes.io/name: frigate
+    app.kubernetes.io/part-of: home-security
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: local-path
+
+---
 # --- PersistentVolumeClaim (media/recordings) ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -273,6 +291,14 @@ spec:
             - name: web
               containerPort: 5000
               protocol: TCP
+          volumeMounts:
+            - name: config-persistent
+              mountPath: /config
+            - name: media
+              mountPath: /media
+            - name: config-file
+              mountPath: /config/config.yml
+              subPath: config.yml
           resources:
             requests:
               cpu: 20m
@@ -299,6 +325,16 @@ spec:
               port: web
             initialDelaySeconds: 5
             periodSeconds: 10
+      volumes:
+        - name: config-persistent
+          persistentVolumeClaim:
+            claimName: frigate-config
+        - name: media
+          persistentVolumeClaim:
+            claimName: frigate-media
+        - name: config-file
+          configMap:
+            name: frigate-config
 
 ---
 # --- Service ---

--- a/k8s/base/zigbee2mqtt/zigbee2mqtt.yaml
+++ b/k8s/base/zigbee2mqtt/zigbee2mqtt.yaml
@@ -112,6 +112,11 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            - name: data
+              mountPath: /app/data
+            - name: config
+              mountPath: /app/data/configuration.yaml
+              subPath: configuration.yaml
           resources:
             requests:
               cpu: 20m
@@ -141,6 +146,12 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
+        - name: data
+          persistentVolumeClaim:
+            claimName: zigbee2mqtt-data
+        - name: config
+          configMap:
+            name: zigbee2mqtt-config
 
 ---
 # --- Service ---

--- a/k8s/overlays/production/kustomization.yaml
+++ b/k8s/overlays/production/kustomization.yaml
@@ -24,6 +24,14 @@ patches:
   # --- Frigate: storage de produção (HDD dedicado) ---
   - target:
       kind: PersistentVolumeClaim
+      name: frigate-config
+    patch: |
+      - op: replace
+        path: /spec/resources/requests/storage
+        value: 20Gi
+
+  - target:
+      kind: PersistentVolumeClaim
       name: frigate-media
     patch: |
       - op: replace

--- a/k8s/overlays/staging/kustomization.yaml
+++ b/k8s/overlays/staging/kustomization.yaml
@@ -85,6 +85,14 @@ patches:
 
   - target:
       kind: PersistentVolumeClaim
+      name: frigate-config
+    patch: |
+      - op: replace
+        path: /spec/resources/requests/storage
+        value: 2Gi
+
+  - target:
+      kind: PersistentVolumeClaim
       name: frigate-media
     patch: |
       - op: replace

--- a/tasks/TASKS_DONE.md
+++ b/tasks/TASKS_DONE.md
@@ -136,6 +136,24 @@
 
 ---
 
+## Agente_DevOps_K3s (concluído em 2026-02-23)
+
+| ID | Título | Data conclusão | Observações |
+|----|--------|----------------|-------------|
+| T-046 | Garantir persistência de dados críticos nos manifests K3s | 2026-02-23 | Deployments de `zigbee2mqtt` e `frigate` atualizados para montagem de PVCs; novo PVC `frigate-config` adicionado; overlays `staging/production` atualizados |
+
+### Entregáveis produzidos pelo Agente_DevOps_K3s
+
+| Arquivo | Descrição |
+|---------|-----------|
+| `k8s/base/zigbee2mqtt/zigbee2mqtt.yaml` | Montagem do PVC `zigbee2mqtt-data` em `/app/data` |
+| `k8s/base/frigate/frigate.yaml` | Novo PVC `frigate-config` e montagem de `frigate-config` + `frigate-media` |
+| `k8s/overlays/production/kustomization.yaml` | Dimensionamento de `frigate-config` para produção |
+| `k8s/overlays/staging/kustomization.yaml` | Dimensionamento de `frigate-config` para homologação |
+| `tests/backend/test_k8s_security_context_contract.py` | Contrato automatizado de persistência para serviços críticos |
+
+---
+
 ## Resumo de progresso
 
 | Categoria | Total | Concluídas | Percentual |

--- a/tests/backend/test_k8s_security_context_contract.py
+++ b/tests/backend/test_k8s_security_context_contract.py
@@ -5,6 +5,8 @@ ROOT = Path(__file__).resolve().parents[2]
 DASHBOARD_K8S = ROOT / "k8s" / "base" / "dashboard" / "dashboard.yaml"
 MOSQUITTO_K8S = ROOT / "k8s" / "base" / "mosquitto" / "mosquitto.yaml"
 Z2M_K8S = ROOT / "k8s" / "base" / "zigbee2mqtt" / "zigbee2mqtt.yaml"
+FRIGATE_K8S = ROOT / "k8s" / "base" / "frigate" / "frigate.yaml"
+HOMEASSISTANT_K8S = ROOT / "k8s" / "base" / "homeassistant" / "homeassistant.yaml"
 
 
 def test_dashboard_manifests_include_baseline_container_hardening():
@@ -41,3 +43,24 @@ def test_zigbee2mqtt_manifest_drops_privileged_and_has_baseline_hardening():
     assert "type: RuntimeDefault" in content
     assert "drop:" in content
     assert "- ALL" in content
+
+
+def test_critical_services_mount_persistent_data_volumes():
+    z2m_content = Z2M_K8S.read_text(encoding="utf-8")
+    frigate_content = FRIGATE_K8S.read_text(encoding="utf-8")
+    ha_content = HOMEASSISTANT_K8S.read_text(encoding="utf-8")
+    mosquitto_content = MOSQUITTO_K8S.read_text(encoding="utf-8")
+
+    assert "claimName: zigbee2mqtt-data" in z2m_content
+    assert "mountPath: /app/data" in z2m_content
+
+    assert "claimName: frigate-config" in frigate_content
+    assert "claimName: frigate-media" in frigate_content
+    assert "mountPath: /config" in frigate_content
+    assert "mountPath: /media" in frigate_content
+
+    assert "claimName: homeassistant-config" in ha_content
+    assert "mountPath: /config" in ha_content
+
+    assert "claimName: mosquitto-data" in mosquitto_content
+    assert "mountPath: /mosquitto/data" in mosquitto_content

--- a/wiki/Operacao-e-Manutencao.md
+++ b/wiki/Operacao-e-Manutencao.md
@@ -104,3 +104,6 @@ Notas para laboratório:
 
 - Sem hardware físico (dongle Zigbee/câmeras), os serviços `zigbee2mqtt` e `frigate` podem operar em modo *stub* para manter o cluster `Ready`.
 - Antes de promover para produção física, reverter para os manifests com integração real de câmera e coordenador Zigbee.
+- Persistência de dados críticos no K3s deve permanecer ativa via PVCs:
+  `postgres-data`, `mosquitto-data`, `homeassistant-config`,
+  `zigbee2mqtt-data`, `frigate-config` e `frigate-media`.

--- a/wiki/Testes-e-Validacao.md
+++ b/wiki/Testes-e-Validacao.md
@@ -192,7 +192,7 @@ Ver `.github/workflows/compliance-gates.yml` para o gate de compliance.
 
 ## Status Atual de Cobertura Automatizada
 
-Data de referência: **2026-02-22**
+Data de referência: **2026-02-23**
 
 Execução local validada:
 
@@ -203,11 +203,14 @@ python3 -m venv .venv
 ```
 
 Resultado mais recente:
-- `82 passed in 0.67s`
+- `83 passed in 0.62s`
 
 Notas:
 - Esta cobertura refere-se à suíte automatizada do diretório `tests/backend`.
 - Itens de validação física e operacional de campo continuam com evidência manual (checklists/runbooks).
+- A suíte inclui contrato para persistência de dados críticos em manifests K8s
+  (`tests/backend/test_k8s_security_context_contract.py`), validando montagem
+  de PVCs em Mosquitto, Home Assistant, Zigbee2MQTT e Frigate.
 
 ### Cobertura de compliance operacional
 


### PR DESCRIPTION
## Resumo
- monta PVC `zigbee2mqtt-data` no deployment do Zigbee2MQTT
- adiciona PVC `frigate-config` e monta `frigate-config` + `frigate-media` no deployment do Frigate
- ajusta overlays de staging e production para o novo PVC
- adiciona contrato de teste para persistencia dos servicos criticos
- atualiza runbook/wiki/tarefas com as novas configuracoes

## Validacao
- .venv/bin/pytest -q tests/backend
- kubectl apply -k k8s/overlays/production
- kubectl -n home-security get pods
- kubectl -n home-security get pvc
- curl -k https://{homeassistant,frigate,zigbee2mqtt,dashboard}-home-security.toca.lan

## Resultado
- 83 passed
- pods principais em Running
- PVCs criticos Bound (exceto `postgres-backup`, esperado por ser WaitForFirstConsumer)
