### PR TITLE
fix(sonar): lote inicial de quick wins (ternary, constants, mocks)

### DIFF
--- a/src/dashboard/backend/app/routers/alerts.py
+++ b/src/dashboard/backend/app/routers/alerts.py
@@ -11,6 +11,8 @@ from app.db.models import Alert, DashboardConfig, DevicePosition
 from app.db.session import get_db
 
 router = APIRouter(prefix="/api", tags=["alerts"])
+MAP_FLOORPLAN_IMAGE_KEY = "map.floorplan_image_data_url"
+MAP_GEO_BOUNDS_KEY = "map.geo_bounds_json"
 
 
 @router.get("/alerts")
@@ -79,10 +81,10 @@ class MapConfigPayload(BaseModel):
 
 @router.get("/map/config")
 async def get_map_config(db: AsyncSession = Depends(get_db)) -> dict:
-    keys = ["map.floorplan_image_data_url", "map.geo_bounds_json"]
+    keys = [MAP_FLOORPLAN_IMAGE_KEY, MAP_GEO_BOUNDS_KEY]
     result = await db.execute(select(DashboardConfig).where(DashboardConfig.key.in_(keys)))
     rows = {row.key: row.value for row in result.scalars().all()}
-    geo_bounds_raw = rows.get("map.geo_bounds_json")
+    geo_bounds_raw = rows.get(MAP_GEO_BOUNDS_KEY)
     geo_bounds = (
         json.loads(geo_bounds_raw)
         if geo_bounds_raw
@@ -94,7 +96,7 @@ async def get_map_config(db: AsyncSession = Depends(get_db)) -> dict:
         }
     )
     return {
-        "floorplan_image_data_url": rows.get("map.floorplan_image_data_url"),
+        "floorplan_image_data_url": rows.get(MAP_FLOORPLAN_IMAGE_KEY),
         "geo_bounds": geo_bounds,
     }
 
@@ -104,14 +106,14 @@ async def upsert_map_config(payload: MapConfigPayload, db: AsyncSession = Depend
     if payload.floorplan_image_data_url is not None:
         await db.merge(
             DashboardConfig(
-                key="map.floorplan_image_data_url",
+                key=MAP_FLOORPLAN_IMAGE_KEY,
                 value=payload.floorplan_image_data_url,
             )
         )
     if payload.geo_bounds is not None:
         await db.merge(
             DashboardConfig(
-                key="map.geo_bounds_json",
+                key=MAP_GEO_BOUNDS_KEY,
                 value=json.dumps(payload.geo_bounds, separators=(",", ":"), ensure_ascii=True),
             )
         )

--- a/src/dashboard/frontend/src/components/DroneStatus.jsx
+++ b/src/dashboard/frontend/src/components/DroneStatus.jsx
@@ -2,7 +2,12 @@ import useStore from '../store/useStore'
 
 function BatteryBar({ percent }) {
   const pct = parseFloat(percent) || 0
-  const color = pct > 50 ? 'bg-success' : pct > 20 ? 'bg-warning' : 'bg-critical'
+  let color = 'bg-critical'
+  if (pct > 50) {
+    color = 'bg-success'
+  } else if (pct > 20) {
+    color = 'bg-warning'
+  }
   return (
     <div className="flex items-center gap-2">
       <div className="flex-1 bg-border rounded-full h-1.5 overflow-hidden">

--- a/src/dashboard/frontend/src/components/SensorGrid.jsx
+++ b/src/dashboard/frontend/src/components/SensorGrid.jsx
@@ -14,21 +14,31 @@ function SensorCard({ id, label, icon }) {
   const state = states[id]?.state ?? 'unavailable'
   const isActive = state === 'on'
   const isUnavailable = state === 'unavailable'
+  let cardClasses = 'border-border bg-surface'
+  let stateTextClass = 'text-success'
+  let stateText = 'ok'
+  let dotClass = 'bg-success'
+
+  if (isUnavailable) {
+    cardClasses = 'border-border bg-surface/50 opacity-50'
+    stateTextClass = 'text-muted'
+    stateText = 'offline'
+    dotClass = 'bg-gray-600'
+  } else if (isActive) {
+    cardClasses = 'border-warning bg-yellow-900/20'
+    stateTextClass = 'text-warning'
+    stateText = 'aberto / detectado'
+    dotClass = 'bg-warning'
+  }
 
   return (
-    <div className={`flex items-center gap-3 p-3 rounded-lg border transition-colors ${
-      isUnavailable ? 'border-border bg-surface/50 opacity-50'
-      : isActive ? 'border-warning bg-yellow-900/20'
-      : 'border-border bg-surface'
-    }`}>
+    <div className={`flex items-center gap-3 p-3 rounded-lg border transition-colors ${cardClasses}`}>
       <span className="text-xl">{icon}</span>
       <div className="min-w-0 flex-1">
         <p className="text-xs text-muted truncate">{label}</p>
-        <p className={`text-sm font-medium ${isActive ? 'text-warning' : isUnavailable ? 'text-muted' : 'text-success'}`}>
-          {isUnavailable ? 'offline' : isActive ? 'aberto / detectado' : 'ok'}
-        </p>
+        <p className={`text-sm font-medium ${stateTextClass}`}>{stateText}</p>
       </div>
-      <span className={`status-dot ${isUnavailable ? 'bg-gray-600' : isActive ? 'bg-warning' : 'bg-success'}`} />
+      <span className={`status-dot ${dotClass}`} />
     </div>
   )
 }

--- a/src/dashboard/frontend/src/hooks/useWebSocket.js
+++ b/src/dashboard/frontend/src/hooks/useWebSocket.js
@@ -1,10 +1,15 @@
 import { useEffect, useRef } from 'react'
 import useStore from '../store/useStore'
 
-const WS_URL =
-  typeof window !== 'undefined'
-    ? `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.host}/ws`
-    : 'ws://localhost:8000/ws'
+function buildWsUrl() {
+  if (typeof window === 'undefined') {
+    return 'ws://localhost:8000/ws'
+  }
+  const wsScheme = window.location.protocol === 'https:' ? 'wss' : 'ws'
+  return `${wsScheme}://${window.location.host}/ws`
+}
+
+const WS_URL = buildWsUrl()
 
 export function useWebSocket() {
   const wsRef = useRef(null)

--- a/src/drones/uav/mavlink_bridge.py
+++ b/src/drones/uav/mavlink_bridge.py
@@ -14,7 +14,10 @@ try:
 except ImportError:
     # Mock defense for now if not found
     class DefenseController:
-        def __init__(self, **kwargs): pass
+        def __init__(self, **kwargs):
+            # Intentional no-op: allows local simulation when common module is absent.
+            _ = kwargs
+
         def get_status(self): return {"state": "mock"}
 
 # Configuration

--- a/src/drones/ugv/app/ugv_control.py
+++ b/src/drones/ugv/app/ugv_control.py
@@ -19,11 +19,21 @@ except ImportError as e:
     print(f"Error importing common modules: {e}")
     # Mock for testing if modules missing
     class HealthMonitor:
-        def __init__(self, **kwargs): pass
+        def __init__(self, **kwargs):
+            # Intentional no-op: allows local simulation when common module is absent.
+            _ = kwargs
+
         def check_health(self): return True, "OK"
-        def update_heartbeat(self): pass
+
+        def update_heartbeat(self):
+            # Intentional no-op for fallback mock implementation.
+            return None
+
     class DefenseController:
-        def __init__(self, **kwargs): pass
+        def __init__(self, **kwargs):
+            # Intentional no-op: allows local simulation when common module is absent.
+            _ = kwargs
+
         def get_status(self): return {"state": "mock"}
 
 # Configuration from Environment Variables

--- a/tests/backend/test_dashboard_api.py
+++ b/tests/backend/test_dashboard_api.py
@@ -6,6 +6,9 @@ from app.db.session import get_db
 from app.routers import alerts, cameras, sensors, services, ws
 from app.security import require_api_key
 
+TEST_BASE_URL = "http://testserver"
+ALARMO_ENTITY_ID = "alarm_control_panel.alarmo"
+
 
 class _FakeScalars:
     def __init__(self, rows):
@@ -29,7 +32,7 @@ class _FakeAlert:
 
         self.id = 1
         self.timestamp = datetime.now(timezone.utc)
-        self.entity_id = "alarm_control_panel.alarmo"
+        self.entity_id = ALARMO_ENTITY_ID
         self.event_type = "state_changed"
         self.old_state = "disarmed"
         self.new_state = "armed_home"
@@ -67,7 +70,7 @@ def _build_test_app():
 async def test_http_routes_require_api_key():
     app = _build_test_app()
     transport = httpx.ASGITransport(app=app)
-    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
         assert (await client.get("/api/sensors")).status_code == 403
         assert (await client.get("/api/cameras/events")).status_code == 403
         assert (await client.get("/api/alerts")).status_code == 403
@@ -82,7 +85,7 @@ async def test_sensors_route_with_api_key(monkeypatch):
 
     app = _build_test_app()
     transport = httpx.ASGITransport(app=app)
-    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
         resp = await client.get("/api/sensors", headers={"X-API-Key": "test-api-key"})
     assert resp.status_code == 200
     assert "states" in resp.json()
@@ -103,7 +106,7 @@ async def test_cameras_routes_with_api_key(monkeypatch):
 
     app = _build_test_app()
     transport = httpx.ASGITransport(app=app)
-    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
         snap = await client.get("/api/cameras/cam_entrada/snapshot", headers={"X-API-Key": "test-api-key"})
         evts = await client.get("/api/cameras/events", headers={"X-API-Key": "test-api-key"})
 
@@ -117,13 +120,13 @@ async def test_cameras_routes_with_api_key(monkeypatch):
 async def test_alerts_route_with_api_key():
     app = _build_test_app()
     transport = httpx.ASGITransport(app=app)
-    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
         resp = await client.get("/api/alerts", headers={"X-API-Key": "test-api-key"})
 
     assert resp.status_code == 200
     payload = resp.json()
     assert isinstance(payload, list)
-    assert payload[0]["entity_id"] == "alarm_control_panel.alarmo"
+    assert payload[0]["entity_id"] == ALARMO_ENTITY_ID
 
 
 @pytest.mark.anyio
@@ -134,11 +137,11 @@ async def test_services_route_with_api_key(monkeypatch):
         return "online"
 
     monkeypatch.setattr(services_router, "_check_http", _ok)
-    monkeypatch.setattr(services_router.ha_client, "get_all_states", lambda: {"alarm_control_panel.alarmo": {"state": "disarmed"}})
+    monkeypatch.setattr(services_router.ha_client, "get_all_states", lambda: {ALARMO_ENTITY_ID: {"state": "disarmed"}})
 
     app = _build_test_app()
     transport = httpx.ASGITransport(app=app)
-    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
         resp = await client.get("/api/services/status", headers={"X-API-Key": "test-api-key"})
         metrics = await client.get("/api/services/ws-metrics", headers={"X-API-Key": "test-api-key"})
 

--- a/tests/backend/test_defense_controller.py
+++ b/tests/backend/test_defense_controller.py
@@ -15,6 +15,7 @@ MODULE_PATH = (
     / "common"
     / "defense_controller.py"
 )
+AUDIT_LOG_NAME = "audit.log"
 
 
 def _load_controller_class():
@@ -37,12 +38,12 @@ def _totp(secret, timestamp=None):
 
 
 def test_arm_requires_pin_and_totp(tmp_path):
-    DefenseController = _load_controller_class()
+    defense_controller_cls = _load_controller_class()
     secret = "JBSWY3DPEHPK3PXP"
-    ctrl = DefenseController(
+    ctrl = defense_controller_cls(
         pin_code="123456",
         totp_secret=secret,
-        audit_log_path=str(tmp_path / "audit.log"),
+        audit_log_path=str(tmp_path / AUDIT_LOG_NAME),
     )
     ok, detail = ctrl.set_mode("semi_auto")
     assert ok and detail == "mode_updated"
@@ -58,11 +59,11 @@ def test_arm_requires_pin_and_totp(tmp_path):
 
 
 def test_automatic_mode_is_forbidden(tmp_path):
-    DefenseController = _load_controller_class()
-    ctrl = DefenseController(
+    defense_controller_cls = _load_controller_class()
+    ctrl = defense_controller_cls(
         pin_code="123456",
         totp_secret="JBSWY3DPEHPK3PXP",
-        audit_log_path=str(tmp_path / "audit.log"),
+        audit_log_path=str(tmp_path / AUDIT_LOG_NAME),
     )
     ok, detail = ctrl.set_mode("automatic")
     assert not ok
@@ -70,16 +71,16 @@ def test_automatic_mode_is_forbidden(tmp_path):
 
 
 def test_fire_flow_enforces_warning_zone_and_daily_limit(tmp_path):
-    DefenseController = _load_controller_class()
+    defense_controller_cls = _load_controller_class()
     secret = "JBSWY3DPEHPK3PXP"
-    ctrl = DefenseController(
+    ctrl = defense_controller_cls(
         pin_code="123456",
         totp_secret=secret,
         warning_seconds=5,
         cooldown_seconds=1,
         max_triggers_per_day=1,
         exclusion_zones=["sidewalk"],
-        audit_log_path=str(tmp_path / "audit.log"),
+        audit_log_path=str(tmp_path / AUDIT_LOG_NAME),
     )
     ctrl.set_mode("semi_auto")
     ok, detail = ctrl.arm("123456", _totp(secret), source_id="test")
@@ -111,10 +112,10 @@ def test_fire_flow_enforces_warning_zone_and_daily_limit(tmp_path):
 
 
 def test_audit_log_keeps_hash_chain(tmp_path):
-    DefenseController = _load_controller_class()
+    defense_controller_cls = _load_controller_class()
     secret = "JBSWY3DPEHPK3PXP"
-    log_file = tmp_path / "audit.log"
-    ctrl = DefenseController(
+    log_file = tmp_path / AUDIT_LOG_NAME
+    ctrl = defense_controller_cls(
         pin_code="123456",
         totp_secret=secret,
         audit_log_path=str(log_file),

--- a/tests/backend/test_k8s_security_context_contract.py
+++ b/tests/backend/test_k8s_security_context_contract.py
@@ -7,16 +7,21 @@ MOSQUITTO_K8S = ROOT / "k8s" / "base" / "mosquitto" / "mosquitto.yaml"
 Z2M_K8S = ROOT / "k8s" / "base" / "zigbee2mqtt" / "zigbee2mqtt.yaml"
 FRIGATE_K8S = ROOT / "k8s" / "base" / "frigate" / "frigate.yaml"
 HOMEASSISTANT_K8S = ROOT / "k8s" / "base" / "homeassistant" / "homeassistant.yaml"
+RUN_AS_NON_ROOT = "runAsNonRoot: true"
+ALLOW_PRIV_ESC_FALSE = "allowPrivilegeEscalation: false"
+READ_ONLY_FS_TRUE = "readOnlyRootFilesystem: true"
+SECCOMP_PROFILE = "seccompProfile:"
+RUNTIME_DEFAULT = "type: RuntimeDefault"
 
 
 def test_dashboard_manifests_include_baseline_container_hardening():
     content = DASHBOARD_K8S.read_text(encoding="utf-8")
 
-    assert "runAsNonRoot: true" in content
-    assert "allowPrivilegeEscalation: false" in content
-    assert "readOnlyRootFilesystem: true" in content
-    assert "seccompProfile:" in content
-    assert "type: RuntimeDefault" in content
+    assert RUN_AS_NON_ROOT in content
+    assert ALLOW_PRIV_ESC_FALSE in content
+    assert READ_ONLY_FS_TRUE in content
+    assert SECCOMP_PROFILE in content
+    assert RUNTIME_DEFAULT in content
     assert "drop:" in content
     assert "- ALL" in content
 
@@ -25,22 +30,22 @@ def test_mosquitto_manifest_includes_baseline_container_hardening():
     content = MOSQUITTO_K8S.read_text(encoding="utf-8")
 
     assert "runAsUser: 1883" in content
-    assert "runAsNonRoot: true" in content
-    assert "allowPrivilegeEscalation: false" in content
-    assert "readOnlyRootFilesystem: true" in content
-    assert "seccompProfile:" in content
-    assert "type: RuntimeDefault" in content
+    assert RUN_AS_NON_ROOT in content
+    assert ALLOW_PRIV_ESC_FALSE in content
+    assert READ_ONLY_FS_TRUE in content
+    assert SECCOMP_PROFILE in content
+    assert RUNTIME_DEFAULT in content
 
 
 def test_zigbee2mqtt_manifest_drops_privileged_and_has_baseline_hardening():
     content = Z2M_K8S.read_text(encoding="utf-8")
 
     assert "privileged: true" not in content
-    assert "runAsNonRoot: true" in content
-    assert "allowPrivilegeEscalation: false" in content
-    assert "readOnlyRootFilesystem: true" in content
-    assert "seccompProfile:" in content
-    assert "type: RuntimeDefault" in content
+    assert RUN_AS_NON_ROOT in content
+    assert ALLOW_PRIV_ESC_FALSE in content
+    assert READ_ONLY_FS_TRUE in content
+    assert SECCOMP_PROFILE in content
+    assert RUNTIME_DEFAULT in content
     assert "drop:" in content
     assert "- ALL" in content
 

--- a/tests/integration_ugv_mqtt.py
+++ b/tests/integration_ugv_mqtt.py
@@ -23,12 +23,12 @@ received_status = False
 received_detection = False
 current_ugv_state = None
 
-def on_connect(client, userdata, flags, rc):
+def on_connect(client, _userdata, _flags, rc):
     print(f"Connected to Broker (RC: {rc})")
     client.subscribe(TOPIC_STATUS)
     client.subscribe(TOPIC_DETECTIONS)
 
-def on_message(client, userdata, msg):
+def on_message(_client, _userdata, msg):
     global received_status, received_detection, current_ugv_state
     
     try:


### PR DESCRIPTION
## Resumo
- remove ternarios aninhados no frontend (`SensorGrid`, `DroneStatus`, `useWebSocket`)
- extrai literais duplicados para constantes em rotas e testes
- corrige nomes de variaveis locais em testes para padrao snake_case
- remove parametros nao usados em callbacks MQTT de teste
- adiciona implementacao explicita (no-op documentado) em mocks usados quando imports falham

## Testes executados
- `.venv/bin/pytest -q tests/backend/test_dashboard_api.py tests/backend/test_defense_controller.py tests/backend/test_k8s_security_context_contract.py`
  - resultado: `13 passed`
- `npm run lint` (frontend)
  - observacao: falhou por ausencia de configuracao ESLint no ambiente local

## Issues
Closes #229
Closes #230
Closes #231
Closes #232
Closes #233
Closes #234
Closes #236
Closes #237
Closes #238
Closes #239
Closes #240
Closes #241
Closes #242
Closes #248
Closes #250
Closes #251
Closes #252
Closes #253
Closes #254
Closes #255
Closes #256
Closes #257
Closes #258
Closes #259
Closes #260
Closes #261
Closes #262
Closes #263
Closes #265
Closes #266
Closes #267
Closes #268
Closes #269
Closes #270
Closes #272
Closes #273
Closes #274
Closes #275
Closes #276
Closes #277
Closes #278
Closes #284
Closes #286
Closes #287
Closes #288
Closes #289
Closes #290
Closes #291
Closes #292
Closes #293
Closes #294
Closes #295
Closes #296
Closes #297
Closes #298
Closes #299
