### PR TITLE
feat(db): catálogo de ativos com trilha de auditoria — closes #335

### DIFF
--- a/src/dashboard/backend/app/db/models.py
+++ b/src/dashboard/backend/app/db/models.py
@@ -1,6 +1,18 @@
+import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import DateTime, Float, Index, Integer, String, Text
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    Uuid,
+)
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
@@ -53,3 +65,110 @@ class DashboardConfig(Base):
 
     key: Mapped[str] = mapped_column(String(100), primary_key=True)
     value: Mapped[str | None] = mapped_column(Text)
+
+
+class Asset(Base):
+    """Catálogo de ativos do sistema de segurança (sensores, câmeras, UGV, UAV)."""
+
+    __tablename__ = "assets"
+    __table_args__ = (
+        CheckConstraint(
+            "asset_type IN ('sensor', 'camera', 'ugv', 'uav')",
+            name="ck_assets_asset_type",
+        ),
+        CheckConstraint(
+            "status IN ('active', 'inactive', 'offline', 'maintenance')",
+            name="ck_assets_status",
+        ),
+        Index("ix_dashboard_assets_asset_type", "asset_type"),
+        Index("ix_dashboard_assets_is_active", "is_active"),
+        Index("ix_dashboard_assets_updated_at", "updated_at"),
+        {"schema": "dashboard"},
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    asset_type: Mapped[str] = mapped_column(
+        String(20), nullable=False
+    )  # sensor|camera|ugv|uav
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    entity_id: Mapped[str] = mapped_column(String(200), unique=True, nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(20), default="active"
+    )  # active|inactive|offline|maintenance
+    location: Mapped[str | None] = mapped_column(String(200))
+    description: Mapped[str | None] = mapped_column(Text)
+    config_json: Mapped[str | None] = mapped_column(Text)  # JSON com config por tipo
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+    created_by: Mapped[str | None] = mapped_column(String(100))
+    updated_by: Mapped[str | None] = mapped_column(String(100))
+
+
+class AssetCredential(Base):
+    """Referências de credenciais de ativos — armazenamento seguro sem exposição ao frontend."""
+
+    __tablename__ = "asset_credentials"
+    __table_args__ = {"schema": "dashboard"}
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    asset_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(as_uuid=True),
+        ForeignKey("dashboard.assets.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    credential_ref: Mapped[str] = mapped_column(
+        String(500), nullable=False
+    )  # alias/vault ref, nunca o valor real
+    last_rotated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+
+class AssetAudit(Base):
+    """Trilha de auditoria para todas as operações no catálogo de ativos."""
+
+    __tablename__ = "asset_audit"
+    __table_args__ = (
+        CheckConstraint(
+            "action IN ('create', 'update', 'delete', 'restore')",
+            name="ck_asset_audit_action",
+        ),
+        Index("ix_dashboard_asset_audit_asset_id", "asset_id"),
+        Index("ix_dashboard_asset_audit_created_at", "created_at"),
+        Index("ix_dashboard_asset_audit_actor", "actor"),
+        {"schema": "dashboard"},
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    asset_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid(as_uuid=True), index=True
+    )  # nullable para deleções permanentes
+    action: Mapped[str] = mapped_column(
+        String(20), nullable=False
+    )  # create|update|delete|restore
+    before_json: Mapped[str | None] = mapped_column(Text)  # estado anterior (JSON)
+    after_json: Mapped[str | None] = mapped_column(Text)  # estado posterior (JSON)
+    actor: Mapped[str | None] = mapped_column(String(100))  # usuário/sistema que executou
+    actor_ip: Mapped[str | None] = mapped_column(String(45))  # IPv4 ou IPv6
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+        index=True,
+    )

--- a/src/dashboard/backend/migrations/versions/20260223_0003_assets_catalog_and_audit.py
+++ b/src/dashboard/backend/migrations/versions/20260223_0003_assets_catalog_and_audit.py
@@ -1,0 +1,221 @@
+"""add assets catalog, credentials and audit trail
+
+Revision ID: 20260223_0003
+Revises: 20260219_0002
+Create Date: 2026-02-23 00:00:00
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260223_0003"
+down_revision: Union[str, None] = "20260219_0002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # --- tabela principal de ativos ---
+    op.create_table(
+        "assets",
+        sa.Column("id", sa.Uuid(as_uuid=True), nullable=False),
+        sa.Column("asset_type", sa.String(length=20), nullable=False),
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column("entity_id", sa.String(length=200), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="active"),
+        sa.Column("location", sa.String(length=200), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("config_json", sa.Text(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("created_by", sa.String(length=100), nullable=True),
+        sa.Column("updated_by", sa.String(length=100), nullable=True),
+        sa.CheckConstraint(
+            "asset_type IN ('sensor', 'camera', 'ugv', 'uav')",
+            name="ck_assets_asset_type",
+        ),
+        sa.CheckConstraint(
+            "status IN ('active', 'inactive', 'offline', 'maintenance')",
+            name="ck_assets_status",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("entity_id"),
+        schema="dashboard",
+    )
+    op.create_index(
+        "ix_dashboard_assets_asset_type",
+        "assets",
+        ["asset_type"],
+        unique=False,
+        schema="dashboard",
+    )
+    op.create_index(
+        "ix_dashboard_assets_is_active",
+        "assets",
+        ["is_active"],
+        unique=False,
+        schema="dashboard",
+    )
+    op.create_index(
+        "ix_dashboard_assets_updated_at",
+        "assets",
+        ["updated_at"],
+        unique=False,
+        schema="dashboard",
+    )
+
+    # --- tabela de credenciais (apenas referências, sem valores reais) ---
+    op.create_table(
+        "asset_credentials",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("asset_id", sa.Uuid(as_uuid=True), nullable=False),
+        sa.Column("credential_ref", sa.String(length=500), nullable=False),
+        sa.Column("last_rotated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["asset_id"],
+            ["dashboard.assets.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        schema="dashboard",
+    )
+    op.create_index(
+        "ix_dashboard_asset_credentials_asset_id",
+        "asset_credentials",
+        ["asset_id"],
+        unique=False,
+        schema="dashboard",
+    )
+
+    # --- trilha de auditoria ---
+    op.create_table(
+        "asset_audit",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("asset_id", sa.Uuid(as_uuid=True), nullable=True),
+        sa.Column("action", sa.String(length=20), nullable=False),
+        sa.Column("before_json", sa.Text(), nullable=True),
+        sa.Column("after_json", sa.Text(), nullable=True),
+        sa.Column("actor", sa.String(length=100), nullable=True),
+        sa.Column("actor_ip", sa.String(length=45), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.CheckConstraint(
+            "action IN ('create', 'update', 'delete', 'restore')",
+            name="ck_asset_audit_action",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        schema="dashboard",
+    )
+    op.create_index(
+        "ix_dashboard_asset_audit_asset_id",
+        "asset_audit",
+        ["asset_id"],
+        unique=False,
+        schema="dashboard",
+    )
+    op.create_index(
+        "ix_dashboard_asset_audit_created_at",
+        "asset_audit",
+        ["created_at"],
+        unique=False,
+        schema="dashboard",
+    )
+    op.create_index(
+        "ix_dashboard_asset_audit_actor",
+        "asset_audit",
+        ["actor"],
+        unique=False,
+        schema="dashboard",
+    )
+
+    # --- backfill: migrar device_positions -> assets ---
+    op.execute(
+        """
+        INSERT INTO dashboard.assets (id, asset_type, name, entity_id, status, location,
+                                      is_active, created_at, updated_at, created_by)
+        SELECT
+            gen_random_uuid(),
+            CASE device_type
+                WHEN 'camera' THEN 'camera'
+                WHEN 'drone'  THEN 'ugv'
+                ELSE 'sensor'
+            END,
+            label,
+            entity_id,
+            'active',
+            NULL,
+            true,
+            now(),
+            now(),
+            'migration_backfill'
+        FROM dashboard.device_positions
+        ON CONFLICT (entity_id) DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_dashboard_asset_audit_actor",
+        table_name="asset_audit",
+        schema="dashboard",
+    )
+    op.drop_index(
+        "ix_dashboard_asset_audit_created_at",
+        table_name="asset_audit",
+        schema="dashboard",
+    )
+    op.drop_index(
+        "ix_dashboard_asset_audit_asset_id",
+        table_name="asset_audit",
+        schema="dashboard",
+    )
+    op.drop_table("asset_audit", schema="dashboard")
+
+    op.drop_index(
+        "ix_dashboard_asset_credentials_asset_id",
+        table_name="asset_credentials",
+        schema="dashboard",
+    )
+    op.drop_table("asset_credentials", schema="dashboard")
+
+    op.drop_index(
+        "ix_dashboard_assets_updated_at",
+        table_name="assets",
+        schema="dashboard",
+    )
+    op.drop_index(
+        "ix_dashboard_assets_is_active",
+        table_name="assets",
+        schema="dashboard",
+    )
+    op.drop_index(
+        "ix_dashboard_assets_asset_type",
+        table_name="assets",
+        schema="dashboard",
+    )
+    op.drop_table("assets", schema="dashboard")

--- a/tests/backend/test_db_migrations.py
+++ b/tests/backend/test_db_migrations.py
@@ -1,6 +1,10 @@
 import asyncio
+import importlib.util
+import os
+import uuid
 
 from app.db import session as db_session
+from app.db.models import Asset, AssetAudit, AssetCredential
 
 
 class _FakeConfig:
@@ -32,3 +36,193 @@ def test_init_db_uses_alembic_upgrade_head(monkeypatch):
     assert calls["revision"] == "head"
     assert calls["config"].options["script_location"].endswith("migrations")
     assert calls["config"].options["sqlalchemy.url"].startswith("postgresql+psycopg://")
+
+
+# ---------------------------------------------------------------------------
+# Testes de modelos — Issue #335
+# ---------------------------------------------------------------------------
+
+
+class TestAssetModel:
+    """Valida estrutura e defaults do modelo Asset."""
+
+    def test_asset_model_has_required_fields(self):
+        asset = Asset(
+            id=uuid.uuid4(),
+            asset_type="sensor",
+            name="Sensor Porta",
+            entity_id="binary_sensor.porta_entrada",
+            status="active",
+            is_active=True,
+        )
+        assert asset.asset_type == "sensor"
+        assert asset.name == "Sensor Porta"
+        assert asset.entity_id == "binary_sensor.porta_entrada"
+        assert asset.status == "active"
+        assert asset.is_active is True
+
+    def test_asset_types_accepted(self):
+        for asset_type in ("sensor", "camera", "ugv", "uav"):
+            asset = Asset(
+                id=uuid.uuid4(),
+                asset_type=asset_type,
+                name=f"Ativo {asset_type}",
+                entity_id=f"test.{asset_type}_{uuid.uuid4().hex[:6]}",
+                status="active",
+                is_active=True,
+            )
+            assert asset.asset_type == asset_type
+
+    def test_asset_status_accepted(self):
+        for status in ("active", "inactive", "offline", "maintenance"):
+            asset = Asset(
+                id=uuid.uuid4(),
+                asset_type="sensor",
+                name="Teste",
+                entity_id=f"test.sensor_{uuid.uuid4().hex[:6]}",
+                status=status,
+                is_active=True,
+            )
+            assert asset.status == status
+
+    def test_asset_id_is_uuid(self):
+        asset_id = uuid.uuid4()
+        asset = Asset(
+            id=asset_id,
+            asset_type="camera",
+            name="Camera Entrada",
+            entity_id="camera.entrada",
+            status="active",
+            is_active=True,
+        )
+        assert asset.id == asset_id
+        assert isinstance(asset.id, uuid.UUID)
+
+    def test_asset_optional_fields_accept_none(self):
+        asset = Asset(
+            id=uuid.uuid4(),
+            asset_type="sensor",
+            name="Sensor",
+            entity_id="binary_sensor.test",
+            status="active",
+            is_active=True,
+            location=None,
+            description=None,
+            config_json=None,
+            created_by=None,
+            updated_by=None,
+        )
+        assert asset.location is None
+        assert asset.description is None
+        assert asset.config_json is None
+
+
+class TestAssetCredentialModel:
+    """Valida estrutura do modelo AssetCredential."""
+
+    def test_credential_stores_reference_not_secret(self):
+        asset_id = uuid.uuid4()
+        cred = AssetCredential(
+            asset_id=asset_id,
+            credential_ref="vault://cameras/cam_entrada/rtsp_password",
+        )
+        assert cred.asset_id == asset_id
+        assert cred.credential_ref.startswith("vault://")
+        assert cred.last_rotated_at is None
+
+    def test_credential_ref_is_not_plain_password(self):
+        cred = AssetCredential(
+            asset_id=uuid.uuid4(),
+            credential_ref="k8s://secret/cam-credentials/rtsp_url",
+        )
+        assert "://" in cred.credential_ref  # deve ser uma referência com scheme
+
+
+class TestAssetAuditModel:
+    """Valida estrutura e variantes de ação do modelo AssetAudit."""
+
+    def test_audit_create(self):
+        audit = AssetAudit(
+            asset_id=uuid.uuid4(),
+            action="create",
+            after_json='{"name":"Sensor","asset_type":"sensor"}',
+            actor="admin",
+            actor_ip="192.168.1.100",
+        )
+        assert audit.action == "create"
+        assert audit.before_json is None
+
+    def test_audit_update(self):
+        audit = AssetAudit(
+            asset_id=uuid.uuid4(),
+            action="update",
+            before_json='{"status":"active"}',
+            after_json='{"status":"inactive"}',
+            actor="operator",
+        )
+        assert audit.action == "update"
+        assert audit.before_json is not None
+        assert audit.after_json is not None
+
+    def test_audit_delete(self):
+        audit = AssetAudit(
+            asset_id=uuid.uuid4(),
+            action="delete",
+            before_json='{"name":"Sensor Removido","asset_type":"sensor"}',
+            actor="admin",
+        )
+        assert audit.action == "delete"
+        assert audit.after_json is None
+
+    def test_audit_restore(self):
+        audit = AssetAudit(
+            asset_id=uuid.uuid4(),
+            action="restore",
+            after_json='{"is_active":true}',
+            actor="admin",
+        )
+        assert audit.action == "restore"
+
+    def test_audit_asset_id_nullable(self):
+        audit = AssetAudit(
+            asset_id=None,
+            action="delete",
+            before_json='{"entity_id":"sensor.deletado_permanentemente"}',
+            actor="system",
+        )
+        assert audit.asset_id is None
+
+
+class TestMigration0003:
+    """Valida integridade do arquivo de migração 0003."""
+
+    def _load_migration(self):
+        base = os.path.dirname(__file__)
+        path = os.path.join(
+            base,
+            "../../src/dashboard/backend/migrations/versions",
+            "20260223_0003_assets_catalog_and_audit.py",
+        )
+        spec = importlib.util.spec_from_file_location("migration_0003", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_migration_file_exists(self):
+        base = os.path.dirname(__file__)
+        path = os.path.join(
+            base,
+            "../../src/dashboard/backend/migrations/versions",
+            "20260223_0003_assets_catalog_and_audit.py",
+        )
+        assert os.path.isfile(path), f"Migração 0003 não encontrada em {path}"
+
+    def test_migration_revision(self):
+        mod = self._load_migration()
+        assert mod.revision == "20260223_0003"
+        assert mod.down_revision == "20260219_0002"
+
+    def test_migration_has_upgrade_and_downgrade(self):
+        mod = self._load_migration()
+        assert callable(mod.upgrade)
+        assert callable(mod.downgrade)


### PR DESCRIPTION
## Resumo

Implementa Issue #335 — modelagem e migrações do catálogo de ativos.

- **Modelos SQLAlchemy** novos em `models.py`:
  - `Asset`: tabela principal com UUID pk, `asset_type` (sensor/camera/ugv/uav), `status`, `is_active`, timestamps e `config_json`
  - `AssetCredential`: referências seguras de credenciais (sem exposição de valor ao frontend)
  - `AssetAudit`: trilha completa com action, before/after JSON, actor e actor_ip

- **Migration `20260223_0003`**: cria as 3 tabelas, índices otimizados e executa backfill automático de `device_positions → assets`

- **Testes**: `test_db_migrations.py` atualizado com classes `TestAssetModel`, `TestAssetCredentialModel`, `TestAssetAuditModel` e `TestMigration0003`

## Plano de rollback

```bash
alembic downgrade 20260219_0002
```

## Checklist
- [x] Migrações sobem/descem sem erro
- [x] Constraints de tipo e status definidas
- [x] Backfill de device_positions → assets
- [x] Testes de modelos e migração
- [x] Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)