### PR TITLE
feat(backend): API CRUD de ativos, RBAC e trilha de auditoria — closes #336 #338 #339

### DIFF
--- a/src/dashboard/backend/app/config.py
+++ b/src/dashboard/backend/app/config.py
@@ -18,6 +18,7 @@ class Settings(BaseSettings):
 
     # Dashboard API security
     dashboard_api_key: str = ""
+    dashboard_admin_key: str = ""  # chave de nível admin para CRUD de ativos
     dashboard_allowed_origins: list[str] = [
         "http://localhost:3000",
         "http://127.0.0.1:3000",
@@ -74,6 +75,18 @@ class Settings(BaseSettings):
         upper_secret = secret.upper()
         if "CHANGE_ME" in upper_secret or "UNCONFIGURED" in upper_secret:
             raise ValueError(f"{info.field_name.upper()} contains insecure placeholder value.")
+        return secret
+
+    @field_validator("dashboard_admin_key")
+    @classmethod
+    def validate_admin_key(cls, value: str) -> str:
+        """Admin key é opcional; se configurado, não pode ser placeholder."""
+        secret = (value or "").strip()
+        if not secret:
+            return secret  # permitido ser vazio (RBAC admin desabilitado)
+        upper = secret.upper()
+        if "CHANGE_ME" in upper or "UNCONFIGURED" in upper:
+            raise ValueError("DASHBOARD_ADMIN_KEY contains insecure placeholder value.")
         return secret
 
 

--- a/src/dashboard/backend/app/main.py
+++ b/src/dashboard/backend/app/main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
 from app.db.session import init_db
-from app.routers import alerts, cameras, drones, sensors, services, ws
+from app.routers import alerts, assets, audit, cameras, drones, sensors, services, ws
 from app.security import require_api_key
 from app.services import frigate_client, ha_client
 
@@ -53,8 +53,8 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.dashboard_allowed_origins,
     allow_credentials=True,
-    allow_methods=["GET", "POST", "PUT", "OPTIONS"],
-    allow_headers=["Authorization", "Content-Type", "X-API-Key"],
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type", "X-API-Key", "X-Admin-Key", "X-Actor"],
 )
 
 # Routers
@@ -64,6 +64,10 @@ app.include_router(cameras.router, dependencies=[Depends(require_api_key)])
 app.include_router(alerts.router, dependencies=[Depends(require_api_key)])
 app.include_router(drones.router, dependencies=[Depends(require_api_key)])
 app.include_router(services.router, dependencies=[Depends(require_api_key)])
+# Catálogo de ativos (leitura: operator; escrita: admin via X-Admin-Key nos endpoints)
+app.include_router(assets.router, dependencies=[Depends(require_api_key)])
+# Trilha de auditoria (leitura: operator)
+app.include_router(audit.router, dependencies=[Depends(require_api_key)])
 
 
 @app.get("/health")

--- a/src/dashboard/backend/app/routers/alerts.py
+++ b/src/dashboard/backend/app/routers/alerts.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, field_validator
 from sqlalchemy import desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.db.models import Alert, DashboardConfig, DevicePosition
+from app.db.models import Alert, Asset, DashboardConfig, DevicePosition
 from app.db.session import get_db
 
 router = APIRouter(prefix="/api", tags=["alerts"])
@@ -45,7 +45,33 @@ async def list_alerts(
 
 @router.get("/map/devices")
 async def list_device_positions(db: AsyncSession = Depends(get_db)) -> list[dict]:
-    """Retorna posições dos dispositivos no mapa operacional."""
+    """Retorna posições dos dispositivos no mapa operacional.
+
+    Prioriza o catálogo dinâmico de ativos (dashboard.assets).
+    Fallback para device_positions legadas se catálogo estiver vazio.
+    """
+    # Tenta catálogo dinâmico de ativos
+    assets_result = await db.execute(
+        select(Asset).where(Asset.is_active == True)  # noqa: E712
+    )
+    assets = assets_result.scalars().all()
+
+    if assets:
+        return [
+            {
+                "entity_id": a.entity_id,
+                "label": a.name,
+                "x": 50.0,  # posição padrão; ajustável via device_positions
+                "y": 50.0,
+                "device_type": a.asset_type if a.asset_type in ("camera", "sensor") else "drone",
+                "asset_id": str(a.id),
+                "asset_type": a.asset_type,
+                "status": a.status,
+            }
+            for a in assets
+        ]
+
+    # Fallback: device_positions legadas
     result = await db.execute(select(DevicePosition))
     devices = result.scalars().all()
     return [

--- a/src/dashboard/backend/app/routers/assets.py
+++ b/src/dashboard/backend/app/routers/assets.py
@@ -1,0 +1,363 @@
+"""Router de Cadastro e Gestão de Ativos — Issues #336, #338, #339."""
+
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from pydantic import BaseModel, Field, field_validator
+from sqlalchemy import desc, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import Asset, AssetAudit, AssetCredential
+from app.db.session import get_db
+from app.security import require_admin_key
+
+router = APIRouter(prefix="/api/assets", tags=["assets"])
+
+# ---------------------------------------------------------------------------
+# Schemas Pydantic
+# ---------------------------------------------------------------------------
+
+AssetType = Literal["sensor", "camera", "ugv", "uav"]
+AssetStatus = Literal["active", "inactive", "offline", "maintenance"]
+
+
+class AssetCreate(BaseModel):
+    asset_type: AssetType
+    name: str = Field(..., min_length=1, max_length=200)
+    entity_id: str = Field(..., min_length=1, max_length=200)
+    status: AssetStatus = "active"
+    location: str | None = Field(default=None, max_length=200)
+    description: str | None = None
+    config_json: str | None = None  # JSON de configuração por tipo
+
+    @field_validator("entity_id")
+    @classmethod
+    def validate_entity_id(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("entity_id cannot be empty.")
+        if " " in value:
+            raise ValueError("entity_id cannot contain spaces.")
+        return value
+
+    @field_validator("config_json")
+    @classmethod
+    def validate_config_json(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        try:
+            json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise ValueError("config_json must be valid JSON.") from exc
+        return value
+
+
+class AssetUpdate(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    status: AssetStatus | None = None
+    location: str | None = Field(default=None, max_length=200)
+    description: str | None = None
+    config_json: str | None = None
+    is_active: bool | None = None
+
+    @field_validator("config_json")
+    @classmethod
+    def validate_config_json(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        try:
+            json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise ValueError("config_json must be valid JSON.") from exc
+        return value
+
+
+def _asset_to_dict(a: Asset) -> dict:
+    """Serializa Asset para resposta — sem credenciais sensíveis."""
+    return {
+        "id": str(a.id),
+        "asset_type": a.asset_type,
+        "name": a.name,
+        "entity_id": a.entity_id,
+        "status": a.status,
+        "location": a.location,
+        "description": a.description,
+        "config_json": a.config_json,
+        "is_active": a.is_active,
+        "created_at": a.created_at.isoformat() if a.created_at else None,
+        "updated_at": a.updated_at.isoformat() if a.updated_at else None,
+        "created_by": a.created_by,
+        "updated_by": a.updated_by,
+    }
+
+
+def _get_actor(request: Request) -> str:
+    return request.headers.get("X-Actor", "api")
+
+
+def _get_actor_ip(request: Request) -> str:
+    forwarded = request.headers.get("X-Forwarded-For")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+async def _write_audit(
+    db: AsyncSession,
+    *,
+    asset_id: uuid.UUID | None,
+    action: str,
+    before: dict | None,
+    after: dict | None,
+    actor: str,
+    actor_ip: str,
+) -> None:
+    audit = AssetAudit(
+        asset_id=asset_id,
+        action=action,
+        before_json=json.dumps(before, default=str) if before else None,
+        after_json=json.dumps(after, default=str) if after else None,
+        actor=actor,
+        actor_ip=actor_ip,
+    )
+    db.add(audit)
+
+
+# ---------------------------------------------------------------------------
+# Endpoints — leitura (require_api_key via main.py)
+# ---------------------------------------------------------------------------
+
+
+@router.get("", summary="Listar ativos com filtros e paginação")
+async def list_assets(
+    asset_type: str | None = Query(default=None),
+    status: str | None = Query(default=None),
+    is_active: bool | None = Query(default=None),
+    search: str | None = Query(default=None, max_length=200),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """GET /api/assets — Retorna catálogo de ativos com filtros opcionais."""
+    stmt = select(Asset).order_by(desc(Asset.updated_at))
+    if asset_type:
+        stmt = stmt.where(Asset.asset_type == asset_type)
+    if status:
+        stmt = stmt.where(Asset.status == status)
+    if is_active is not None:
+        stmt = stmt.where(Asset.is_active == is_active)
+    if search:
+        like = f"%{search}%"
+        stmt = stmt.where(Asset.name.ilike(like) | Asset.entity_id.ilike(like))
+
+    count_stmt = select(func.count()).select_from(stmt.subquery())
+    total_result = await db.execute(count_stmt)
+    total = total_result.scalar_one()
+
+    result = await db.execute(stmt.offset(offset).limit(limit))
+    assets = result.scalars().all()
+    return {
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+        "items": [_asset_to_dict(a) for a in assets],
+    }
+
+
+@router.get("/{asset_id}", summary="Obter ativo por ID")
+async def get_asset(asset_id: uuid.UUID, db: AsyncSession = Depends(get_db)) -> dict:
+    """GET /api/assets/{id} — Retorna um ativo específico."""
+    result = await db.execute(select(Asset).where(Asset.id == asset_id))
+    asset = result.scalar_one_or_none()
+    if not asset:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Asset not found.")
+    return _asset_to_dict(asset)
+
+
+# ---------------------------------------------------------------------------
+# Endpoints — escrita (require_admin_key — Issue #338)
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "",
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_admin_key)],
+    summary="Criar novo ativo (admin)",
+)
+async def create_asset(
+    payload: AssetCreate,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """POST /api/assets — Cadastra novo ativo. Requer X-Admin-Key."""
+    existing = await db.execute(select(Asset).where(Asset.entity_id == payload.entity_id))
+    if existing.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Asset with entity_id '{payload.entity_id}' already exists.",
+        )
+
+    actor = _get_actor(request)
+    actor_ip = _get_actor_ip(request)
+    now = datetime.now(timezone.utc)
+    asset = Asset(
+        id=uuid.uuid4(),
+        asset_type=payload.asset_type,
+        name=payload.name,
+        entity_id=payload.entity_id,
+        status=payload.status,
+        location=payload.location,
+        description=payload.description,
+        config_json=payload.config_json,
+        is_active=True,
+        created_at=now,
+        updated_at=now,
+        created_by=actor,
+        updated_by=actor,
+    )
+    db.add(asset)
+    await db.flush()  # gera id para auditoria
+
+    await _write_audit(
+        db,
+        asset_id=asset.id,
+        action="create",
+        before=None,
+        after=_asset_to_dict(asset),
+        actor=actor,
+        actor_ip=actor_ip,
+    )
+    await db.commit()
+    await db.refresh(asset)
+    return _asset_to_dict(asset)
+
+
+@router.put(
+    "/{asset_id}",
+    dependencies=[Depends(require_admin_key)],
+    summary="Atualizar ativo (admin)",
+)
+async def update_asset(
+    asset_id: uuid.UUID,
+    payload: AssetUpdate,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """PUT /api/assets/{id} — Atualiza campos de um ativo. Requer X-Admin-Key."""
+    result = await db.execute(select(Asset).where(Asset.id == asset_id))
+    asset = result.scalar_one_or_none()
+    if not asset:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Asset not found.")
+
+    before = _asset_to_dict(asset)
+    actor = _get_actor(request)
+    actor_ip = _get_actor_ip(request)
+
+    if payload.name is not None:
+        asset.name = payload.name
+    if payload.status is not None:
+        asset.status = payload.status
+    if payload.location is not None:
+        asset.location = payload.location
+    if payload.description is not None:
+        asset.description = payload.description
+    if payload.config_json is not None:
+        asset.config_json = payload.config_json
+    if payload.is_active is not None:
+        asset.is_active = payload.is_active
+    asset.updated_at = datetime.now(timezone.utc)
+    asset.updated_by = actor
+
+    await _write_audit(
+        db,
+        asset_id=asset.id,
+        action="update",
+        before=before,
+        after=_asset_to_dict(asset),
+        actor=actor,
+        actor_ip=actor_ip,
+    )
+    await db.commit()
+    await db.refresh(asset)
+    return _asset_to_dict(asset)
+
+
+@router.delete(
+    "/{asset_id}",
+    dependencies=[Depends(require_admin_key)],
+    summary="Desativar ativo (soft delete) (admin)",
+)
+async def delete_asset(
+    asset_id: uuid.UUID,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """DELETE /api/assets/{id} — Soft delete: marca is_active=False. Requer X-Admin-Key."""
+    result = await db.execute(select(Asset).where(Asset.id == asset_id))
+    asset = result.scalar_one_or_none()
+    if not asset:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Asset not found.")
+
+    before = _asset_to_dict(asset)
+    actor = _get_actor(request)
+    actor_ip = _get_actor_ip(request)
+
+    asset.is_active = False
+    asset.status = "inactive"
+    asset.updated_at = datetime.now(timezone.utc)
+    asset.updated_by = actor
+
+    await _write_audit(
+        db,
+        asset_id=asset.id,
+        action="delete",
+        before=before,
+        after=_asset_to_dict(asset),
+        actor=actor,
+        actor_ip=actor_ip,
+    )
+    await db.commit()
+    return {"status": "deactivated", "id": str(asset_id)}
+
+
+@router.post(
+    "/{asset_id}/restore",
+    dependencies=[Depends(require_admin_key)],
+    summary="Restaurar ativo desativado (admin)",
+)
+async def restore_asset(
+    asset_id: uuid.UUID,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """POST /api/assets/{id}/restore — Reativa ativo. Requer X-Admin-Key."""
+    result = await db.execute(select(Asset).where(Asset.id == asset_id))
+    asset = result.scalar_one_or_none()
+    if not asset:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Asset not found.")
+
+    before = _asset_to_dict(asset)
+    actor = _get_actor(request)
+    actor_ip = _get_actor_ip(request)
+
+    asset.is_active = True
+    asset.status = "active"
+    asset.updated_at = datetime.now(timezone.utc)
+    asset.updated_by = actor
+
+    await _write_audit(
+        db,
+        asset_id=asset.id,
+        action="restore",
+        before=before,
+        after=_asset_to_dict(asset),
+        actor=actor,
+        actor_ip=actor_ip,
+    )
+    await db.commit()
+    await db.refresh(asset)
+    return _asset_to_dict(asset)

--- a/src/dashboard/backend/app/routers/audit.py
+++ b/src/dashboard/backend/app/routers/audit.py
@@ -1,0 +1,117 @@
+"""Router de Trilha de Auditoria — Issue #339."""
+
+import csv
+import io
+import json
+import uuid
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Query, Response
+from sqlalchemy import desc, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import AssetAudit
+from app.db.session import get_db
+
+router = APIRouter(prefix="/api/audit", tags=["audit"])
+
+
+def _audit_to_dict(a: AssetAudit) -> dict:
+    return {
+        "id": a.id,
+        "asset_id": str(a.asset_id) if a.asset_id else None,
+        "action": a.action,
+        "before_json": a.before_json,
+        "after_json": a.after_json,
+        "actor": a.actor,
+        "actor_ip": a.actor_ip,
+        "created_at": a.created_at.isoformat() if a.created_at else None,
+    }
+
+
+@router.get("", summary="Consultar trilha de auditoria com filtros")
+async def list_audit(
+    asset_id: uuid.UUID | None = Query(default=None),
+    action: str | None = Query(default=None, description="create|update|delete|restore"),
+    actor: str | None = Query(default=None),
+    since: datetime | None = Query(default=None, description="ISO 8601 — data inicial"),
+    until: datetime | None = Query(default=None, description="ISO 8601 — data final"),
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """GET /api/audit — Retorna trilha de auditoria paginada com filtros opcionais."""
+    stmt = select(AssetAudit).order_by(desc(AssetAudit.created_at))
+
+    if asset_id:
+        stmt = stmt.where(AssetAudit.asset_id == asset_id)
+    if action:
+        stmt = stmt.where(AssetAudit.action == action)
+    if actor:
+        stmt = stmt.where(AssetAudit.actor == actor)
+    if since:
+        stmt = stmt.where(AssetAudit.created_at >= since)
+    if until:
+        stmt = stmt.where(AssetAudit.created_at <= until)
+
+    count_stmt = select(func.count()).select_from(stmt.subquery())
+    total_result = await db.execute(count_stmt)
+    total = total_result.scalar_one()
+
+    result = await db.execute(stmt.offset(offset).limit(limit))
+    records = result.scalars().all()
+    return {
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+        "items": [_audit_to_dict(r) for r in records],
+    }
+
+
+@router.get("/export", summary="Exportar trilha de auditoria (CSV ou JSON)")
+async def export_audit(
+    format: str = Query(default="json", description="json ou csv"),
+    asset_id: uuid.UUID | None = Query(default=None),
+    action: str | None = Query(default=None),
+    actor: str | None = Query(default=None),
+    since: datetime | None = Query(default=None),
+    until: datetime | None = Query(default=None),
+    limit: int = Query(default=1000, ge=1, le=5000),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """GET /api/audit/export — Exporta registros de auditoria em CSV ou JSON."""
+    stmt = select(AssetAudit).order_by(desc(AssetAudit.created_at))
+
+    if asset_id:
+        stmt = stmt.where(AssetAudit.asset_id == asset_id)
+    if action:
+        stmt = stmt.where(AssetAudit.action == action)
+    if actor:
+        stmt = stmt.where(AssetAudit.actor == actor)
+    if since:
+        stmt = stmt.where(AssetAudit.created_at >= since)
+    if until:
+        stmt = stmt.where(AssetAudit.created_at <= until)
+
+    result = await db.execute(stmt.limit(limit))
+    records = [_audit_to_dict(r) for r in result.scalars().all()]
+
+    if format.lower() == "csv":
+        output = io.StringIO()
+        if records:
+            writer = csv.DictWriter(output, fieldnames=records[0].keys())
+            writer.writeheader()
+            writer.writerows(records)
+        content = output.getvalue()
+        return Response(
+            content=content,
+            media_type="text/csv",
+            headers={"Content-Disposition": "attachment; filename=audit_export.csv"},
+        )
+
+    content = json.dumps(records, ensure_ascii=False, indent=2)
+    return Response(
+        content=content,
+        media_type="application/json",
+        headers={"Content-Disposition": "attachment; filename=audit_export.json"},
+    )

--- a/src/dashboard/backend/app/security.py
+++ b/src/dashboard/backend/app/security.py
@@ -9,6 +9,7 @@ from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBea
 from app.config import settings
 
 _api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+_admin_key_header = APIKeyHeader(name="X-Admin-Key", auto_error=False)
 _bearer_scheme = HTTPBearer(auto_error=False)
 _api_auth_failures: MutableMapping[str, deque[float]] = defaultdict(deque)
 _ws_auth_attempts: MutableMapping[str, deque[float]] = defaultdict(deque)
@@ -16,6 +17,11 @@ _AUTH_WINDOW_SECONDS = 60
 _AUTH_MAX_FAILURES_PER_WINDOW = 20
 _WS_AUTH_WINDOW_SECONDS = 60
 _WS_AUTH_MAX_ATTEMPTS_PER_WINDOW = 60
+
+# Rate limit para operações admin (menor tolerância)
+_admin_auth_failures: MutableMapping[str, deque[float]] = defaultdict(deque)
+_ADMIN_AUTH_WINDOW_SECONDS = 60
+_ADMIN_AUTH_MAX_FAILURES_PER_WINDOW = 10
 
 
 def _configured_api_key() -> str:
@@ -73,6 +79,43 @@ async def require_api_key(
     ):
         raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Too many auth failures.")
     raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid API key.")
+
+
+async def require_admin_key(
+    request: Request,
+    x_admin_key: str | None = Security(_admin_key_header),
+) -> None:
+    """Exige chave de nível admin (DASHBOARD_ADMIN_KEY) para operações CRUD de ativos.
+
+    Se DASHBOARD_ADMIN_KEY não estiver configurado, todas as operações admin são bloqueadas
+    (fail-secure: sem chave admin configurada = sem acesso admin).
+    """
+    admin_key = (settings.dashboard_admin_key or "").strip()
+    if not admin_key:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Admin key not configured. Set DASHBOARD_ADMIN_KEY to enable asset management.",
+        )
+
+    ip = _client_ip(request.client.host if request.client else None)
+    if _is_valid_api_key(x_admin_key, admin_key):
+        return
+
+    if not _register_rate_event(
+        _admin_auth_failures,
+        ip,
+        now=time.time(),
+        window_seconds=_ADMIN_AUTH_WINDOW_SECONDS,
+        max_events=_ADMIN_AUTH_MAX_FAILURES_PER_WINDOW,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many admin auth failures.",
+        )
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Invalid admin key. Use X-Admin-Key header.",
+    )
 
 
 async def require_ws_api_key(websocket: WebSocket) -> None:

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -9,6 +9,7 @@ sys.path.insert(0, str(BACKEND_DIR))
 # Required by app.config.Settings at import time
 os.environ.setdefault("HA_TOKEN", "test-ha-token")
 os.environ.setdefault("DASHBOARD_API_KEY", "test-api-key")
+os.environ.setdefault("DASHBOARD_ADMIN_KEY", "test-admin-key")
 os.environ.setdefault(
     "DATABASE_URL",
     "postgresql+asyncpg://dashboard_user:test@localhost/homedb?options=-csearch_path%3Ddashboard",

--- a/tests/backend/test_assets_api.py
+++ b/tests/backend/test_assets_api.py
@@ -1,0 +1,389 @@
+"""Testes de contrato da API de Cadastro de Ativos — Issues #336, #338, #339."""
+
+import json
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from fastapi import Depends, FastAPI
+
+from app.db.session import get_db
+from app.routers import assets as assets_router
+from app.routers import audit as audit_router
+from app.security import require_api_key
+
+OPERATOR_KEY = "test-api-key"
+ADMIN_KEY = "test-admin-key"
+TEST_BASE_URL = "http://testserver"
+
+
+# ---------------------------------------------------------------------------
+# Helpers de fixtures de DB
+# ---------------------------------------------------------------------------
+
+
+def _make_asset(
+    asset_type="sensor",
+    entity_id="binary_sensor.porta",
+    name="Sensor Porta",
+    status="active",
+    is_active=True,
+) -> MagicMock:
+    a = MagicMock()
+    a.id = uuid.uuid4()
+    a.asset_type = asset_type
+    a.name = name
+    a.entity_id = entity_id
+    a.status = status
+    a.location = "entrada"
+    a.description = None
+    a.config_json = None
+    a.is_active = is_active
+    a.created_at = datetime.now(timezone.utc)
+    a.updated_at = datetime.now(timezone.utc)
+    a.created_by = "test"
+    a.updated_by = "test"
+    return a
+
+
+class _FakeScalars:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+    def scalar_one(self):
+        return len(self._rows)
+
+    def scalar_one_or_none(self):
+        return self._rows[0] if self._rows else None
+
+
+class _FakeResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalars(self):
+        return _FakeScalars(self._rows)
+
+    def scalar_one(self):
+        return len(self._rows)
+
+    def scalar_one_or_none(self):
+        return self._rows[0] if self._rows else None
+
+
+class _FakeSession:
+    def __init__(self, rows=None, conflict=False):
+        self._rows = rows or []
+        self._conflict = conflict
+        self.added = []
+
+    async def execute(self, _stmt):
+        return _FakeResult(self._rows)
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def flush(self):
+        pass
+
+    async def commit(self):
+        pass
+
+    async def refresh(self, obj):
+        pass
+
+
+def _build_test_app(db_rows=None, conflict=False):
+    fake_session = _FakeSession(rows=db_rows, conflict=conflict)
+
+    async def _override_get_db():
+        yield fake_session
+
+    app = FastAPI()
+    app.include_router(assets_router.router, dependencies=[Depends(require_api_key)])
+    app.include_router(audit_router.router, dependencies=[Depends(require_api_key)])
+    app.dependency_overrides[get_db] = _override_get_db
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Testes de autenticação (Issue #338 — RBAC)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_list_assets_requires_operator_key():
+    """GET /api/assets deve exigir X-API-Key (operator)."""
+    app = _build_test_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        resp = await client.get("/api/assets")
+    assert resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_list_assets_with_operator_key():
+    """GET /api/assets com X-API-Key retorna 200."""
+    app = _build_test_app(db_rows=[_make_asset()])
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        resp = await client.get("/api/assets", headers={"X-API-Key": OPERATOR_KEY})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "items" in data
+    assert "total" in data
+
+
+@pytest.mark.anyio
+async def test_create_asset_requires_admin_key():
+    """POST /api/assets sem X-Admin-Key deve retornar 503 (admin key não configurada para teste vazio)
+    ou 403 (admin key inválida)."""
+    app = _build_test_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        # Sem admin key — deve falhar (apenas operator key)
+        resp = await client.post(
+            "/api/assets",
+            headers={"X-API-Key": OPERATOR_KEY},
+            json={
+                "asset_type": "sensor",
+                "name": "Sensor Teste",
+                "entity_id": "binary_sensor.teste",
+            },
+        )
+    assert resp.status_code in (403, 503)  # sem X-Admin-Key
+
+
+@pytest.mark.anyio
+async def test_create_asset_with_wrong_admin_key():
+    """POST /api/assets com X-Admin-Key errada deve retornar 403."""
+    app = _build_test_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        resp = await client.post(
+            "/api/assets",
+            headers={"X-API-Key": OPERATOR_KEY, "X-Admin-Key": "wrong-key"},
+            json={
+                "asset_type": "sensor",
+                "name": "Sensor Teste",
+                "entity_id": "binary_sensor.teste",
+            },
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_delete_asset_requires_admin_key():
+    """DELETE /api/assets/{id} sem X-Admin-Key deve falhar."""
+    asset_id = uuid.uuid4()
+    app = _build_test_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        resp = await client.delete(
+            f"/api/assets/{asset_id}",
+            headers={"X-API-Key": OPERATOR_KEY},
+        )
+    assert resp.status_code in (403, 503)
+
+
+# ---------------------------------------------------------------------------
+# Testes de CRUD (Issue #336)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_list_assets_empty():
+    """GET /api/assets sem ativos retorna lista vazia."""
+    app = _build_test_app(db_rows=[])
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        resp = await client.get("/api/assets", headers={"X-API-Key": OPERATOR_KEY})
+    assert resp.status_code == 200
+    assert resp.json()["items"] == []
+
+
+@pytest.mark.anyio
+async def test_list_assets_pagination_params():
+    """GET /api/assets aceita limit e offset como query params."""
+    app = _build_test_app(db_rows=[_make_asset() for _ in range(3)])
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        resp = await client.get(
+            "/api/assets?limit=2&offset=1",
+            headers={"X-API-Key": OPERATOR_KEY},
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["limit"] == 2
+    assert data["offset"] == 1
+
+
+@pytest.mark.anyio
+async def test_get_asset_not_found():
+    """GET /api/assets/{id} com ID inexistente retorna 404."""
+    app = _build_test_app(db_rows=[])
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        resp = await client.get(
+            f"/api/assets/{uuid.uuid4()}",
+            headers={"X-API-Key": OPERATOR_KEY},
+        )
+    assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_get_asset_found():
+    """GET /api/assets/{id} com ID existente retorna o ativo."""
+    asset = _make_asset()
+    app = _build_test_app(db_rows=[asset])
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        resp = await client.get(
+            f"/api/assets/{asset.id}",
+            headers={"X-API-Key": OPERATOR_KEY},
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["entity_id"] == asset.entity_id
+    assert data["asset_type"] == asset.asset_type
+
+
+@pytest.mark.anyio
+async def test_create_asset_invalid_payload():
+    """POST /api/assets com payload inválido retorna 422."""
+    app = _build_test_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        resp = await client.post(
+            "/api/assets",
+            headers={"X-API-Key": OPERATOR_KEY, "X-Admin-Key": ADMIN_KEY},
+            json={"asset_type": "invalid_type", "name": "X", "entity_id": "test.x"},
+        )
+    assert resp.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_create_asset_entity_id_with_space():
+    """POST /api/assets com entity_id contendo espaço retorna 422."""
+    app = _build_test_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        resp = await client.post(
+            "/api/assets",
+            headers={"X-API-Key": OPERATOR_KEY, "X-Admin-Key": ADMIN_KEY},
+            json={"asset_type": "sensor", "name": "X", "entity_id": "binary sensor.teste"},
+        )
+    assert resp.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_create_asset_invalid_config_json():
+    """POST /api/assets com config_json inválido retorna 422."""
+    app = _build_test_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        resp = await client.post(
+            "/api/assets",
+            headers={"X-API-Key": OPERATOR_KEY, "X-Admin-Key": ADMIN_KEY},
+            json={
+                "asset_type": "sensor",
+                "name": "Sensor",
+                "entity_id": "binary_sensor.ok",
+                "config_json": "not-valid-json{{{",
+            },
+        )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Testes de campos de resposta (Issue #338 — sem credenciais sensíveis)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_asset_response_has_no_sensitive_fields():
+    """Resposta da API de ativos não deve expor campos sensíveis."""
+    asset = _make_asset()
+    app = _build_test_app(db_rows=[asset])
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        resp = await client.get(
+            f"/api/assets/{asset.id}",
+            headers={"X-API-Key": OPERATOR_KEY},
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    # Campos sensíveis NÃO devem aparecer na resposta
+    assert "credential" not in str(data).lower()
+    assert "password" not in str(data).lower()
+    assert "secret" not in str(data).lower()
+    # Campos esperados devem estar presentes
+    assert "id" in data
+    assert "asset_type" in data
+    assert "entity_id" in data
+    assert "name" in data
+    assert "status" in data
+    assert "is_active" in data
+
+
+# ---------------------------------------------------------------------------
+# Testes de Auditoria (Issue #339)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_audit_list_requires_operator_key():
+    """GET /api/audit deve exigir X-API-Key."""
+    app = _build_test_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        resp = await client.get("/api/audit")
+    assert resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_audit_list_with_operator_key():
+    """GET /api/audit com X-API-Key retorna 200."""
+    app = _build_test_app(db_rows=[])
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        resp = await client.get("/api/audit", headers={"X-API-Key": OPERATOR_KEY})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "items" in data
+    assert "total" in data
+
+
+@pytest.mark.anyio
+async def test_audit_export_json_format():
+    """GET /api/audit/export?format=json retorna Content-Type application/json."""
+    app = _build_test_app(db_rows=[])
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        resp = await client.get(
+            "/api/audit/export?format=json",
+            headers={"X-API-Key": OPERATOR_KEY},
+        )
+    assert resp.status_code == 200
+    assert "application/json" in resp.headers.get("content-type", "")
+    assert "attachment" in resp.headers.get("content-disposition", "")
+
+
+@pytest.mark.anyio
+async def test_audit_export_csv_format():
+    """GET /api/audit/export?format=csv retorna Content-Type text/csv."""
+    app = _build_test_app(db_rows=[])
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        resp = await client.get(
+            "/api/audit/export?format=csv",
+            headers={"X-API-Key": OPERATOR_KEY},
+        )
+    assert resp.status_code == 200
+    assert "text/csv" in resp.headers.get("content-type", "")
+    assert "attachment" in resp.headers.get("content-disposition", "")

--- a/tests/backend/test_rbac_assets_contract.py
+++ b/tests/backend/test_rbac_assets_contract.py
@@ -1,0 +1,244 @@
+"""Testes de contrato de RBAC para operações de ativos — Issue #338."""
+
+import pytest
+
+
+class TestRBACMatrix:
+    """Valida a matriz de permissões definida na Issue #338."""
+
+    def test_rbac_matrix_viewer_only_read(self):
+        """viewer: somente leitura — endpoints GET são permitidos, POST/PUT/DELETE exigem admin."""
+        # Esta é uma validação de design: leitura pública (com operator key), escrita requer admin
+        readonly_methods = ["GET"]
+        write_methods = ["POST", "PUT", "DELETE"]
+
+        # Valida que a separação está clara na implementação
+        from app.routers.assets import router
+
+        routes = {route.path: list(route.methods) for route in router.routes}
+
+        # /api/assets GET deve ser read-only (sem require_admin_key no nível do router)
+        get_routes = [path for path, methods in routes.items() if "GET" in methods]
+        assert len(get_routes) > 0, "Deve haver rotas GET para ativos"
+
+    def test_admin_key_required_for_create(self):
+        """Endpoint de criação deve ter require_admin_key como dependência."""
+        from app.routers.assets import router
+        from app.security import require_admin_key
+
+        for route in router.routes:
+            if hasattr(route, "methods") and "POST" in route.methods:
+                if route.path == "/api/assets":  # rota de criação
+                    dep_funcs = [
+                        d.dependency for d in route.dependencies if hasattr(d, "dependency")
+                    ]
+                    assert require_admin_key in dep_funcs, (
+                        "POST /api/assets deve ter require_admin_key"
+                    )
+
+    def test_admin_key_required_for_delete(self):
+        """Endpoint de deleção deve ter require_admin_key."""
+        from app.routers.assets import router
+        from app.security import require_admin_key
+
+        for route in router.routes:
+            if hasattr(route, "methods") and "DELETE" in route.methods:
+                dep_funcs = [
+                    d.dependency for d in route.dependencies if hasattr(d, "dependency")
+                ]
+                assert require_admin_key in dep_funcs, (
+                    f"DELETE {route.path} deve ter require_admin_key"
+                )
+
+    def test_admin_key_required_for_update(self):
+        """Endpoint de atualização deve ter require_admin_key."""
+        from app.routers.assets import router
+        from app.security import require_admin_key
+
+        for route in router.routes:
+            if hasattr(route, "methods") and "PUT" in route.methods:
+                dep_funcs = [
+                    d.dependency for d in route.dependencies if hasattr(d, "dependency")
+                ]
+                assert require_admin_key in dep_funcs, (
+                    f"PUT {route.path} deve ter require_admin_key"
+                )
+
+
+class TestRBACAdminKeyConfig:
+    """Valida que a configuração de admin key falha de forma segura."""
+
+    def test_admin_key_fail_secure_when_empty(self, monkeypatch):
+        """Se DASHBOARD_ADMIN_KEY não configurado, operações admin devem ser bloqueadas (503)."""
+        import asyncio
+        from unittest.mock import MagicMock
+
+        from fastapi import HTTPException
+
+        # Patch settings para admin key vazia
+        from app import config as cfg_module
+
+        original_key = cfg_module.settings.dashboard_admin_key
+        monkeypatch.setattr(cfg_module.settings, "dashboard_admin_key", "")
+
+        from app.security import require_admin_key
+
+        req = MagicMock()
+        req.client = MagicMock()
+        req.client.host = "127.0.0.1"
+        req.headers = {}
+
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(require_admin_key(request=req, x_admin_key=None))
+
+        assert exc_info.value.status_code == 503
+        assert "Admin key not configured" in str(exc_info.value.detail)
+
+    def test_admin_key_rejects_wrong_key(self, monkeypatch):
+        """Admin key errada deve retornar 403."""
+        import asyncio
+        from unittest.mock import MagicMock
+
+        from fastapi import HTTPException
+
+        from app import config as cfg_module
+
+        monkeypatch.setattr(cfg_module.settings, "dashboard_admin_key", "correct-admin-key")
+
+        from app.security import require_admin_key
+
+        req = MagicMock()
+        req.client = MagicMock()
+        req.client.host = "127.0.0.1"
+        req.headers = {}
+
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(require_admin_key(request=req, x_admin_key="wrong-key"))
+
+        assert exc_info.value.status_code == 403
+
+    def test_admin_key_accepts_correct_key(self, monkeypatch):
+        """Admin key correta não deve levantar exceção."""
+        import asyncio
+        from unittest.mock import MagicMock
+
+        from app import config as cfg_module
+
+        monkeypatch.setattr(cfg_module.settings, "dashboard_admin_key", "correct-admin-key")
+
+        from app.security import require_admin_key
+
+        req = MagicMock()
+        req.client = MagicMock()
+        req.client.host = "127.0.0.1"
+        req.headers = {}
+
+        # Não deve levantar exceção
+        result = asyncio.run(require_admin_key(request=req, x_admin_key="correct-admin-key"))
+        assert result is None
+
+
+class TestCredentialMasking:
+    """Valida que credenciais sensíveis não são expostas na API — Issue #338."""
+
+    def test_asset_serializer_excludes_credentials(self):
+        """_asset_to_dict não deve incluir o campo de credenciais."""
+        from unittest.mock import MagicMock
+        import uuid
+        from datetime import datetime, timezone
+
+        from app.routers.assets import _asset_to_dict
+
+        asset = MagicMock()
+        asset.id = uuid.uuid4()
+        asset.asset_type = "camera"
+        asset.name = "Camera Entrada"
+        asset.entity_id = "camera.entrada"
+        asset.status = "active"
+        asset.location = "entrada"
+        asset.description = None
+        asset.config_json = None
+        asset.is_active = True
+        asset.created_at = datetime.now(timezone.utc)
+        asset.updated_at = datetime.now(timezone.utc)
+        asset.created_by = "admin"
+        asset.updated_by = "admin"
+
+        result = _asset_to_dict(asset)
+
+        # Campos de credencial NÃO devem estar presentes
+        assert "credential_ref" not in result
+        assert "password" not in result
+        assert "secret" not in result
+        # AssetCredential é uma tabela separada — nunca join automático
+
+    def test_asset_response_does_not_include_credential_ref(self):
+        """A resposta do asset não deve incluir referência de credencial."""
+        from app.routers.assets import _asset_to_dict
+        from unittest.mock import MagicMock
+        import uuid
+        from datetime import datetime, timezone
+
+        asset = MagicMock()
+        asset.id = uuid.uuid4()
+        asset.asset_type = "camera"
+        asset.name = "Camera"
+        asset.entity_id = "camera.test"
+        asset.status = "active"
+        asset.location = None
+        asset.description = None
+        asset.config_json = None
+        asset.is_active = True
+        asset.created_at = datetime.now(timezone.utc)
+        asset.updated_at = datetime.now(timezone.utc)
+        asset.created_by = "system"
+        asset.updated_by = "system"
+
+        serialized = _asset_to_dict(asset)
+        serialized_str = str(serialized)
+        assert "credential" not in serialized_str.lower()
+
+
+class TestRBACEndpointCoverage:
+    """Valida que todos os endpoints de escrita têm RBAC configurado."""
+
+    def test_all_write_endpoints_have_admin_dependency(self):
+        """Todos os endpoints POST/PUT/DELETE em /api/assets devem ter require_admin_key."""
+        from app.routers.assets import router
+        from app.security import require_admin_key
+
+        write_routes = [
+            route
+            for route in router.routes
+            if hasattr(route, "methods")
+            and any(m in route.methods for m in ("POST", "PUT", "DELETE"))
+        ]
+
+        assert len(write_routes) > 0, "Deve haver endpoints de escrita"
+
+        for route in write_routes:
+            dep_funcs = [
+                d.dependency for d in route.dependencies if hasattr(d, "dependency")
+            ]
+            assert require_admin_key in dep_funcs, (
+                f"Endpoint {route.methods} {route.path} não tem require_admin_key"
+            )
+
+    def test_get_endpoints_do_not_require_admin(self):
+        """Endpoints GET não devem exigir admin key (apenas operator key via main.py)."""
+        from app.routers.assets import router
+        from app.security import require_admin_key
+
+        get_routes = [
+            route
+            for route in router.routes
+            if hasattr(route, "methods") and "GET" in route.methods
+        ]
+
+        for route in get_routes:
+            dep_funcs = [
+                d.dependency for d in route.dependencies if hasattr(d, "dependency")
+            ]
+            assert require_admin_key not in dep_funcs, (
+                f"GET {route.path} não deve exigir admin key"
+            )


### PR DESCRIPTION
## Resumo

Implementa Issues #336, #338 e #339 — backend completo do módulo de cadastro de ativos.

### Issue #336 — API CRUD de Ativos
- `GET /api/assets` — listagem paginada com filtros (type, status, is_active, busca textual)
- `GET /api/assets/{id}` — ativo por ID
- `POST /api/assets` — criação com validação Pydantic e auditoria
- `PUT /api/assets/{id}` — atualização parcial com diff auditado
- `DELETE /api/assets/{id}` — soft delete (is_active=False) com auditoria
- `POST /api/assets/{id}/restore` — reativação com auditoria
- `/api/map/devices` atualizado: prioriza catálogo dinâmico, fallback para device_positions legadas

### Issue #338 — RBAC e Hardening
- `require_admin_key`: nova dependency via `X-Admin-Key` header
- Rate limit: 10 falhas/60s para operações admin (mais restritivo que operator)
- Fail-secure: sem `DASHBOARD_ADMIN_KEY` configurado → todos os endpoints admin retornam 503
- Credenciais mascaradas: `_asset_to_dict` jamais expõe `credential_ref`
- CORS: `DELETE` + `X-Admin-Key` + `X-Actor` adicionados

### Issue #339 — Trilha de Auditoria
- `GET /api/audit` — consulta paginada por asset_id/action/actor/período
- `GET /api/audit/export?format=json|csv` — exportação com Content-Disposition
- `_write_audit` helper: grava before/after JSON + actor + actor_ip transacionalmente

## Testes
- `test_assets_api.py`: contrato CRUD, autenticação, campos de resposta
- `test_rbac_assets_contract.py`: matriz RBAC, fail-secure, mascaramento de credenciais

## Checklist
- [x] CRUD funcional com validação de erro consistente
- [x] Endpoints de escrita exigem X-Admin-Key
- [x] Credenciais nunca expostas no frontend
- [x] Auditoria transacional em toda operação
- [x] Exportação CSV e JSON disponível
- [x] Testes de contrato e RBAC
- [x] Closes #336, #338, #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)