### PR TITLE
feat(frontend): módulo de cadastro de ativos no dashboard — closes #337

### DIFF
--- a/src/dashboard/frontend/nginx.conf.template
+++ b/src/dashboard/frontend/nginx.conf.template
@@ -23,6 +23,9 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        # Injeta API key de nível operator (expandida em runtime via envsubst)
+        proxy_set_header X-API-Key "${DASHBOARD_API_KEY}";
+        # X-Admin-Key é passado pelo cliente explicitamente para operações admin
     }
 
     # Proxy WebSocket

--- a/src/dashboard/frontend/src/App.jsx
+++ b/src/dashboard/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import Header from './components/Header'
 import { useWebSocket } from './hooks/useWebSocket'
 import Dashboard from './pages/Dashboard'
 import SimplifiedView from './pages/SimplifiedView'
+import AssetsAdmin from './pages/AssetsAdmin'
 
 function AppLayout() {
   useWebSocket() // Inicia e mantém conexão WebSocket global
@@ -13,6 +14,7 @@ function AppLayout() {
       <Routes>
         <Route path="/" element={<Dashboard />} />
         <Route path="/simplified" element={<SimplifiedView />} />
+        <Route path="/admin/assets" element={<AssetsAdmin />} />
       </Routes>
     </div>
   )

--- a/src/dashboard/frontend/src/components/CameraGrid.jsx
+++ b/src/dashboard/frontend/src/components/CameraGrid.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
+import { useAssets } from '../hooks/useAssets'
 
-const CAMERAS = [
+// Fallback estático — usado quando catálogo dinâmico está vazio
+const STATIC_CAMERAS = [
   { name: 'cam_entrada', label: 'Entrada' },
   { name: 'cam_fundos',  label: 'Fundos' },
   { name: 'cam_garagem', label: 'Garagem' },
@@ -55,11 +57,26 @@ function CameraFeed({ name, label }) {
 }
 
 export default function CameraGrid() {
+  const { cameraAssets } = useAssets()
+
+  // Usa catálogo dinâmico se disponível; fallback estático se vazio
+  const cameras = cameraAssets.length > 0
+    ? cameraAssets.map((a) => ({
+        name: a.entity_id,
+        label: a.name,
+      }))
+    : STATIC_CAMERAS
+
   return (
     <div className="card flex flex-col gap-3">
-      <h2 className="text-xs font-semibold uppercase tracking-wider text-muted">Câmeras</h2>
+      <div className="flex items-center justify-between">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-muted">Câmeras</h2>
+        {cameraAssets.length > 0 && (
+          <span className="text-xs text-accent">{cameraAssets.length} cadastradas</span>
+        )}
+      </div>
       <div className="grid grid-cols-2 gap-2">
-        {CAMERAS.map((cam) => (
+        {cameras.map((cam) => (
           <CameraFeed key={cam.name} {...cam} />
         ))}
       </div>

--- a/src/dashboard/frontend/src/components/CameraGrid.test.jsx
+++ b/src/dashboard/frontend/src/components/CameraGrid.test.jsx
@@ -1,12 +1,45 @@
 import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
 import CameraGrid from "./CameraGrid";
 
+// Mock do hook useAssets para isolar o componente
+vi.mock("../hooks/useAssets", () => ({
+  useAssets: () => ({
+    cameraAssets: [],
+    sensorAssets: [],
+    droneAssets: [],
+    assets: [],
+    assetsLoading: false,
+    assetsError: null,
+    refetch: vi.fn(),
+  }),
+}));
+
 describe("CameraGrid", () => {
-  it("renders all configured cameras", () => {
+  it("renders static fallback cameras when no dynamic assets", () => {
     render(<CameraGrid />);
+    // Com cameraAssets vazio, deve usar STATIC_CAMERAS (fallback)
     expect(screen.getByText("Entrada")).toBeInTheDocument();
     expect(screen.getByText("Fundos")).toBeInTheDocument();
     expect(screen.getByText("Garagem")).toBeInTheDocument();
     expect(screen.getByText("Lateral")).toBeInTheDocument();
+  });
+
+  it("renders dynamic cameras when assets loaded", () => {
+    vi.mocked(require("../hooks/useAssets").useAssets).mockReturnValueOnce({
+      cameraAssets: [
+        { entity_id: "cam_frente", name: "Frente", asset_type: "camera", is_active: true },
+        { entity_id: "cam_quintal", name: "Quintal", asset_type: "camera", is_active: true },
+      ],
+      sensorAssets: [],
+      droneAssets: [],
+      assets: [],
+      assetsLoading: false,
+      assetsError: null,
+      refetch: vi.fn(),
+    });
+    render(<CameraGrid />);
+    expect(screen.getByText("Frente")).toBeInTheDocument();
+    expect(screen.getByText("Quintal")).toBeInTheDocument();
   });
 });

--- a/src/dashboard/frontend/src/components/SensorGrid.jsx
+++ b/src/dashboard/frontend/src/components/SensorGrid.jsx
@@ -1,6 +1,8 @@
 import useStore from '../store/useStore'
+import { useAssets } from '../hooks/useAssets'
 
-const SENSORS = [
+// Fallback estático — usado quando catálogo dinâmico está vazio
+const STATIC_SENSORS = [
   { id: 'binary_sensor.porta_entrada',      label: 'Porta Entrada',  icon: '🚪' },
   { id: 'binary_sensor.porta_fundos',       label: 'Porta Fundos',   icon: '🚪' },
   { id: 'binary_sensor.janela_sala',        label: 'Janela Sala',    icon: '🪟' },
@@ -8,6 +10,25 @@ const SENSORS = [
   { id: 'binary_sensor.pir_corredor',       label: 'PIR Corredor',   icon: '👁' },
   { id: 'binary_sensor.zigbee2mqtt_connection_state', label: 'Zigbee', icon: '📡' },
 ]
+
+const SENSOR_TYPE_ICONS = {
+  pir: '👁',
+  door: '🚪',
+  window: '🪟',
+  smoke: '🔥',
+  motion: '👁',
+  zigbee: '📡',
+}
+
+function getSensorIcon(asset) {
+  const lower = (asset.entity_id + asset.name).toLowerCase()
+  if (lower.includes('porta') || lower.includes('door')) return '🚪'
+  if (lower.includes('janela') || lower.includes('window')) return '🪟'
+  if (lower.includes('pir') || lower.includes('motion')) return '👁'
+  if (lower.includes('smoke') || lower.includes('fumaca')) return '🔥'
+  if (lower.includes('zigbee')) return '📡'
+  return '🔵'
+}
 
 function SensorCard({ id, label, icon }) {
   const { states } = useStore()
@@ -44,12 +65,32 @@ function SensorCard({ id, label, icon }) {
 }
 
 export default function SensorGrid() {
+  const { sensorAssets, assetsLoading } = useAssets()
+
+  // Usa catálogo dinâmico se disponível; fallback estático se vazio
+  const sensors = sensorAssets.length > 0
+    ? sensorAssets.map((a) => ({
+        id: a.entity_id,
+        label: a.name,
+        icon: getSensorIcon(a),
+      }))
+    : STATIC_SENSORS
+
   return (
     <div className="card flex flex-col gap-2">
-      <h2 className="text-xs font-semibold uppercase tracking-wider text-muted mb-1">Sensores</h2>
-      {SENSORS.map((s) => (
-        <SensorCard key={s.id} {...s} />
-      ))}
+      <div className="flex items-center justify-between mb-1">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-muted">Sensores</h2>
+        {sensorAssets.length > 0 && (
+          <span className="text-xs text-accent">{sensorAssets.length} cadastrados</span>
+        )}
+      </div>
+      {assetsLoading && sensorAssets.length === 0 ? (
+        <p className="text-xs text-muted text-center py-2">Carregando...</p>
+      ) : (
+        sensors.map((s) => (
+          <SensorCard key={s.id} {...s} />
+        ))
+      )}
     </div>
   )
 }

--- a/src/dashboard/frontend/src/hooks/useAssets.js
+++ b/src/dashboard/frontend/src/hooks/useAssets.js
@@ -1,0 +1,52 @@
+/**
+ * Hook para buscar e gerenciar o catálogo de ativos — Issue #337.
+ * Lê de /api/assets e sincroniza com o Zustand store.
+ */
+import { useCallback, useEffect } from 'react'
+import useStore from '../store/useStore'
+
+export function useAssets() {
+  const { assets, assetsLoading, assetsError, setAssets, setAssetsLoading, setAssetsError } =
+    useStore()
+
+  const fetchAssets = useCallback(async ({ assetType, isActive } = {}) => {
+    setAssetsLoading(true)
+    setAssetsError(null)
+    try {
+      const params = new URLSearchParams({ limit: '200' })
+      if (assetType) params.set('asset_type', assetType)
+      if (isActive !== undefined) params.set('is_active', String(isActive))
+
+      const resp = await fetch(`/api/assets?${params}`)
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+      const data = await resp.json()
+      setAssets(data.items ?? [])
+    } catch (err) {
+      setAssetsError(err.message)
+    } finally {
+      setAssetsLoading(false)
+    }
+  }, [])
+
+  // Carrega catálogo na montagem
+  useEffect(() => {
+    fetchAssets()
+  }, [])
+
+  // Filtra por tipo
+  const sensorAssets = assets.filter((a) => a.asset_type === 'sensor' && a.is_active)
+  const cameraAssets = assets.filter((a) => a.asset_type === 'camera' && a.is_active)
+  const droneAssets = assets.filter(
+    (a) => (a.asset_type === 'ugv' || a.asset_type === 'uav') && a.is_active,
+  )
+
+  return {
+    assets,
+    sensorAssets,
+    cameraAssets,
+    droneAssets,
+    assetsLoading,
+    assetsError,
+    refetch: fetchAssets,
+  }
+}

--- a/src/dashboard/frontend/src/hooks/useAssets.test.jsx
+++ b/src/dashboard/frontend/src/hooks/useAssets.test.jsx
@@ -1,0 +1,126 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+import { useAssets } from "./useAssets";
+import useStore from "../store/useStore";
+
+describe("useAssets hook", () => {
+  beforeEach(() => {
+    useStore.setState({
+      assets: [],
+      assetsLoading: false,
+      assetsError: null,
+    });
+    vi.clearAllMocks();
+  });
+
+  it("fetches assets on mount and updates store", async () => {
+    const mockAssets = [
+      { id: "1", name: "Sensor A", asset_type: "sensor", is_active: true },
+      { id: "2", name: "Camera B", asset_type: "camera", is_active: true },
+    ];
+
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ items: mockAssets, total: 2 }),
+    });
+
+    const { result } = renderHook(() => useAssets());
+
+    await waitFor(() => {
+      expect(result.current.assets).toHaveLength(2);
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining("/api/assets"));
+    expect(result.current.assetsError).toBeNull();
+    expect(result.current.assetsLoading).toBe(false);
+  });
+
+  it("sets error state on fetch failure", async () => {
+    global.fetch = vi.fn().mockRejectedValueOnce(new Error("Network error"));
+
+    const { result } = renderHook(() => useAssets());
+
+    await waitFor(() => {
+      expect(result.current.assetsError).toBe("Network error");
+    });
+
+    expect(result.current.assetsLoading).toBe(false);
+  });
+
+  it("sets error state on non-ok response", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+    });
+
+    const { result } = renderHook(() => useAssets());
+
+    await waitFor(() => {
+      expect(result.current.assetsError).toBeTruthy();
+    });
+  });
+
+  it("filters sensorAssets correctly", async () => {
+    const mockAssets = [
+      { id: "1", name: "Sensor A", asset_type: "sensor", is_active: true },
+      { id: "2", name: "Camera B", asset_type: "camera", is_active: true },
+      { id: "3", name: "UGV", asset_type: "ugv", is_active: true },
+      { id: "4", name: "UAV", asset_type: "uav", is_active: true },
+      { id: "5", name: "Sensor Inativo", asset_type: "sensor", is_active: false },
+    ];
+
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ items: mockAssets }),
+    });
+
+    const { result } = renderHook(() => useAssets());
+
+    await waitFor(() => {
+      expect(result.current.assets).toHaveLength(5);
+    });
+
+    // Apenas ativos ativos do tipo sensor
+    expect(result.current.sensorAssets).toHaveLength(1);
+    expect(result.current.sensorAssets[0].name).toBe("Sensor A");
+
+    // Camera
+    expect(result.current.cameraAssets).toHaveLength(1);
+    expect(result.current.cameraAssets[0].name).toBe("Camera B");
+
+    // Drones (ugv + uav)
+    expect(result.current.droneAssets).toHaveLength(2);
+  });
+
+  it("refetch loads assets again", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ items: [{ id: "1", name: "A", asset_type: "sensor", is_active: true }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [
+            { id: "1", name: "A", asset_type: "sensor", is_active: true },
+            { id: "2", name: "B", asset_type: "camera", is_active: true },
+          ],
+        }),
+      });
+
+    const { result } = renderHook(() => useAssets());
+
+    await waitFor(() => {
+      expect(result.current.assets).toHaveLength(1);
+    });
+
+    act(() => {
+      result.current.refetch();
+    });
+
+    await waitFor(() => {
+      expect(result.current.assets).toHaveLength(2);
+    });
+  });
+});

--- a/src/dashboard/frontend/src/pages/AssetsAdmin.jsx
+++ b/src/dashboard/frontend/src/pages/AssetsAdmin.jsx
@@ -1,0 +1,499 @@
+/**
+ * Página de Administração de Ativos — Issue #337.
+ * Permite listar, cadastrar, editar e desativar sensores, câmeras, UGV e UAV.
+ */
+import { useState } from 'react'
+import useStore from '../store/useStore'
+import { useAssets } from '../hooks/useAssets'
+
+const ASSET_TYPE_LABELS = {
+  sensor: 'Sensor',
+  camera: 'Câmera',
+  ugv: 'UGV',
+  uav: 'UAV',
+}
+
+const STATUS_LABELS = {
+  active: 'Ativo',
+  inactive: 'Inativo',
+  offline: 'Offline',
+  maintenance: 'Manutenção',
+}
+
+const STATUS_COLORS = {
+  active: 'text-green-400',
+  inactive: 'text-gray-400',
+  offline: 'text-red-400',
+  maintenance: 'text-yellow-400',
+}
+
+const EMPTY_FORM = {
+  asset_type: 'sensor',
+  name: '',
+  entity_id: '',
+  status: 'active',
+  location: '',
+  description: '',
+  config_json: '',
+}
+
+// ---------------------------------------------------------------------------
+// Formulário de criação/edição
+// ---------------------------------------------------------------------------
+function AssetForm({ initial, onSave, onCancel, adminKey }) {
+  const [form, setForm] = useState(initial ?? EMPTY_FORM)
+  const [error, setError] = useState(null)
+  const [saving, setSaving] = useState(false)
+
+  const isEdit = Boolean(initial?.id)
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    if (!adminKey) {
+      setError('Informe a chave de administrador para salvar.')
+      return
+    }
+    setSaving(true)
+    setError(null)
+    try {
+      const body = {
+        asset_type: form.asset_type,
+        name: form.name,
+        entity_id: form.entity_id,
+        status: form.status,
+        location: form.location || null,
+        description: form.description || null,
+        config_json: form.config_json || null,
+      }
+
+      if (form.config_json) {
+        try { JSON.parse(form.config_json) } catch {
+          setError('config_json deve ser JSON válido.')
+          setSaving(false)
+          return
+        }
+      }
+
+      const url = isEdit ? `/api/assets/${initial.id}` : '/api/assets'
+      const method = isEdit ? 'PUT' : 'POST'
+      const resp = await fetch(url, {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Admin-Key': adminKey,
+        },
+        body: JSON.stringify(body),
+      })
+
+      if (!resp.ok) {
+        const err = await resp.json().catch(() => ({ detail: `HTTP ${resp.status}` }))
+        throw new Error(err.detail ?? `HTTP ${resp.status}`)
+      }
+
+      const saved = await resp.json()
+      onSave(saved)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="text-xs text-muted">Tipo *</label>
+          <select
+            value={form.asset_type}
+            onChange={(e) => setForm((f) => ({ ...f, asset_type: e.target.value }))}
+            className="w-full bg-surface border border-border rounded px-2 py-1.5 text-sm text-primary mt-1"
+            required
+          >
+            {Object.entries(ASSET_TYPE_LABELS).map(([v, l]) => (
+              <option key={v} value={v}>{l}</option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="text-xs text-muted">Status *</label>
+          <select
+            value={form.status}
+            onChange={(e) => setForm((f) => ({ ...f, status: e.target.value }))}
+            className="w-full bg-surface border border-border rounded px-2 py-1.5 text-sm text-primary mt-1"
+          >
+            {Object.entries(STATUS_LABELS).map(([v, l]) => (
+              <option key={v} value={v}>{l}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div>
+        <label className="text-xs text-muted">Nome *</label>
+        <input
+          type="text"
+          value={form.name}
+          onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+          className="w-full bg-surface border border-border rounded px-2 py-1.5 text-sm text-primary mt-1"
+          placeholder="ex: Sensor Porta Entrada"
+          required
+          maxLength={200}
+        />
+      </div>
+
+      <div>
+        <label className="text-xs text-muted">Entity ID *</label>
+        <input
+          type="text"
+          value={form.entity_id}
+          onChange={(e) => setForm((f) => ({ ...f, entity_id: e.target.value }))}
+          className="w-full bg-surface border border-border rounded px-2 py-1.5 text-sm text-primary mt-1 font-mono"
+          placeholder="ex: binary_sensor.porta_entrada"
+          required
+          maxLength={200}
+          disabled={isEdit}
+        />
+        {isEdit && <p className="text-xs text-muted mt-1">Entity ID não pode ser alterado.</p>}
+      </div>
+
+      <div>
+        <label className="text-xs text-muted">Localização</label>
+        <input
+          type="text"
+          value={form.location}
+          onChange={(e) => setForm((f) => ({ ...f, location: e.target.value }))}
+          className="w-full bg-surface border border-border rounded px-2 py-1.5 text-sm text-primary mt-1"
+          placeholder="ex: Entrada principal"
+          maxLength={200}
+        />
+      </div>
+
+      <div>
+        <label className="text-xs text-muted">Descrição</label>
+        <textarea
+          value={form.description}
+          onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
+          className="w-full bg-surface border border-border rounded px-2 py-1.5 text-sm text-primary mt-1 resize-none"
+          rows={2}
+          placeholder="Descrição opcional do ativo"
+        />
+      </div>
+
+      <div>
+        <label className="text-xs text-muted">Config JSON (opcional)</label>
+        <textarea
+          value={form.config_json}
+          onChange={(e) => setForm((f) => ({ ...f, config_json: e.target.value }))}
+          className="w-full bg-surface border border-border rounded px-2 py-1.5 text-sm text-primary mt-1 font-mono resize-none"
+          rows={3}
+          placeholder='{"topic": "cmnd/ugv/command"}'
+        />
+      </div>
+
+      {error && (
+        <p className="text-xs text-critical bg-red-900/20 border border-red-800 rounded p-2">
+          {error}
+        </p>
+      )}
+
+      <div className="flex gap-2 justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-3 py-1.5 text-sm text-muted border border-border rounded hover:bg-surface transition-colors"
+        >
+          Cancelar
+        </button>
+        <button
+          type="submit"
+          disabled={saving}
+          className="px-4 py-1.5 text-sm bg-accent text-white rounded hover:bg-accent/80 transition-colors disabled:opacity-50"
+        >
+          {saving ? 'Salvando...' : isEdit ? 'Atualizar' : 'Cadastrar'}
+        </button>
+      </div>
+    </form>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Linha da tabela de ativos
+// ---------------------------------------------------------------------------
+function AssetRow({ asset, onEdit, onDelete, onRestore }) {
+  return (
+    <tr className={`border-b border-border transition-colors ${!asset.is_active ? 'opacity-50' : ''}`}>
+      <td className="px-3 py-2 text-sm text-primary">
+        <span className="font-medium">{asset.name}</span>
+        <br />
+        <span className="text-xs text-muted font-mono">{asset.entity_id}</span>
+      </td>
+      <td className="px-3 py-2 text-sm">
+        <span className="text-xs bg-surface border border-border rounded px-1.5 py-0.5">
+          {ASSET_TYPE_LABELS[asset.asset_type] ?? asset.asset_type}
+        </span>
+      </td>
+      <td className={`px-3 py-2 text-sm ${STATUS_COLORS[asset.status] ?? 'text-muted'}`}>
+        {STATUS_LABELS[asset.status] ?? asset.status}
+      </td>
+      <td className="px-3 py-2 text-xs text-muted">{asset.location ?? '—'}</td>
+      <td className="px-3 py-2 text-xs">
+        <span className={asset.is_active ? 'text-green-400' : 'text-gray-500'}>
+          {asset.is_active ? 'Ativo' : 'Inativo'}
+        </span>
+      </td>
+      <td className="px-3 py-2">
+        <div className="flex gap-1">
+          <button
+            onClick={() => onEdit(asset)}
+            className="text-xs px-2 py-1 text-accent border border-accent/40 rounded hover:bg-accent/10 transition-colors"
+          >
+            Editar
+          </button>
+          {asset.is_active ? (
+            <button
+              onClick={() => onDelete(asset)}
+              className="text-xs px-2 py-1 text-critical border border-critical/40 rounded hover:bg-red-900/20 transition-colors"
+            >
+              Desativar
+            </button>
+          ) : (
+            <button
+              onClick={() => onRestore(asset)}
+              className="text-xs px-2 py-1 text-success border border-success/40 rounded hover:bg-green-900/20 transition-colors"
+            >
+              Restaurar
+            </button>
+          )}
+        </div>
+      </td>
+    </tr>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Página principal
+// ---------------------------------------------------------------------------
+export default function AssetsAdmin() {
+  const { assets, assetsLoading, assetsError, refetch } = useAssets()
+  const { addAsset, updateAsset, removeAsset } = useStore()
+
+  const [showForm, setShowForm] = useState(false)
+  const [editTarget, setEditTarget] = useState(null)
+  const [adminKey, setAdminKey] = useState('')
+  const [filterType, setFilterType] = useState('')
+  const [filterStatus, setFilterStatus] = useState('')
+  const [filterSearch, setFilterSearch] = useState('')
+  const [feedback, setFeedback] = useState(null)
+  const [confirmDelete, setConfirmDelete] = useState(null)
+
+  function showFeedback(msg, isError = false) {
+    setFeedback({ msg, isError })
+    setTimeout(() => setFeedback(null), 4000)
+  }
+
+  function handleSave(saved) {
+    if (editTarget) {
+      updateAsset(saved)
+      showFeedback(`Ativo "${saved.name}" atualizado.`)
+    } else {
+      addAsset(saved)
+      showFeedback(`Ativo "${saved.name}" cadastrado.`)
+    }
+    setShowForm(false)
+    setEditTarget(null)
+  }
+
+  async function handleDelete(asset) {
+    if (!adminKey) { showFeedback('Informe a chave de administrador.', true); return }
+    const confirmed = window.confirm(
+      `Desativar ativo "${asset.name}"? O ativo ficará inativo mas não será removido permanentemente.`,
+    )
+    if (!confirmed) return
+
+    try {
+      const resp = await fetch(`/api/assets/${asset.id}`, {
+        method: 'DELETE',
+        headers: { 'X-Admin-Key': adminKey },
+      })
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+      updateAsset({ ...asset, is_active: false, status: 'inactive' })
+      showFeedback(`Ativo "${asset.name}" desativado.`)
+    } catch (err) {
+      showFeedback(`Erro ao desativar: ${err.message}`, true)
+    }
+  }
+
+  async function handleRestore(asset) {
+    if (!adminKey) { showFeedback('Informe a chave de administrador.', true); return }
+    try {
+      const resp = await fetch(`/api/assets/${asset.id}/restore`, {
+        method: 'POST',
+        headers: { 'X-Admin-Key': adminKey },
+      })
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+      const restored = await resp.json()
+      updateAsset(restored)
+      showFeedback(`Ativo "${asset.name}" restaurado.`)
+    } catch (err) {
+      showFeedback(`Erro ao restaurar: ${err.message}`, true)
+    }
+  }
+
+  // Filtros locais
+  const filtered = assets.filter((a) => {
+    if (filterType && a.asset_type !== filterType) return false
+    if (filterStatus && a.status !== filterStatus) return false
+    if (filterSearch) {
+      const q = filterSearch.toLowerCase()
+      return a.name.toLowerCase().includes(q) || a.entity_id.toLowerCase().includes(q)
+    }
+    return true
+  })
+
+  return (
+    <div className="flex flex-col gap-4 p-4 overflow-y-auto h-full">
+      {/* Cabeçalho */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-lg font-semibold text-primary">Cadastro de Ativos</h1>
+          <p className="text-xs text-muted">Sensores, Câmeras, UGV e UAV</p>
+        </div>
+        <button
+          onClick={() => { setEditTarget(null); setShowForm(true) }}
+          className="px-3 py-1.5 text-sm bg-accent text-white rounded hover:bg-accent/80 transition-colors"
+        >
+          + Novo Ativo
+        </button>
+      </div>
+
+      {/* Chave de administrador */}
+      <div className="card">
+        <label className="text-xs text-muted">Chave de Administrador (X-Admin-Key)</label>
+        <div className="flex gap-2 mt-1">
+          <input
+            type="password"
+            value={adminKey}
+            onChange={(e) => setAdminKey(e.target.value)}
+            className="flex-1 bg-surface border border-border rounded px-2 py-1.5 text-sm text-primary font-mono"
+            placeholder="Necessária para criar, editar ou desativar ativos"
+            autoComplete="off"
+          />
+        </div>
+        <p className="text-xs text-muted mt-1">
+          A chave admin nunca é enviada ao backend em requisições de leitura.
+        </p>
+      </div>
+
+      {/* Feedback */}
+      {feedback && (
+        <div
+          className={`px-3 py-2 rounded text-sm border ${
+            feedback.isError
+              ? 'bg-red-900/20 border-red-800 text-critical'
+              : 'bg-green-900/20 border-green-800 text-success'
+          }`}
+        >
+          {feedback.msg}
+        </div>
+      )}
+
+      {/* Formulário */}
+      {showForm && (
+        <div className="card">
+          <h2 className="text-sm font-semibold text-primary mb-3">
+            {editTarget ? `Editar: ${editTarget.name}` : 'Novo Ativo'}
+          </h2>
+          <AssetForm
+            initial={editTarget}
+            adminKey={adminKey}
+            onSave={handleSave}
+            onCancel={() => { setShowForm(false); setEditTarget(null) }}
+          />
+        </div>
+      )}
+
+      {/* Filtros */}
+      <div className="flex flex-wrap gap-2">
+        <input
+          type="text"
+          value={filterSearch}
+          onChange={(e) => setFilterSearch(e.target.value)}
+          placeholder="Buscar por nome ou entity_id..."
+          className="flex-1 min-w-48 bg-surface border border-border rounded px-2 py-1.5 text-sm text-primary"
+        />
+        <select
+          value={filterType}
+          onChange={(e) => setFilterType(e.target.value)}
+          className="bg-surface border border-border rounded px-2 py-1.5 text-sm text-primary"
+        >
+          <option value="">Todos os tipos</option>
+          {Object.entries(ASSET_TYPE_LABELS).map(([v, l]) => (
+            <option key={v} value={v}>{l}</option>
+          ))}
+        </select>
+        <select
+          value={filterStatus}
+          onChange={(e) => setFilterStatus(e.target.value)}
+          className="bg-surface border border-border rounded px-2 py-1.5 text-sm text-primary"
+        >
+          <option value="">Todos os status</option>
+          {Object.entries(STATUS_LABELS).map(([v, l]) => (
+            <option key={v} value={v}>{l}</option>
+          ))}
+        </select>
+        <button
+          onClick={() => refetch()}
+          className="px-3 py-1.5 text-sm text-muted border border-border rounded hover:bg-surface transition-colors"
+        >
+          ↻ Atualizar
+        </button>
+      </div>
+
+      {/* Tabela */}
+      <div className="card overflow-hidden">
+        {assetsLoading ? (
+          <p className="text-muted text-sm text-center py-6">Carregando ativos...</p>
+        ) : assetsError ? (
+          <p className="text-critical text-sm text-center py-6">Erro: {assetsError}</p>
+        ) : filtered.length === 0 ? (
+          <p className="text-muted text-sm text-center py-6">
+            {assets.length === 0
+              ? 'Nenhum ativo cadastrado. Clique em "+ Novo Ativo" para começar.'
+              : 'Nenhum ativo encontrado com os filtros aplicados.'}
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="px-3 py-2 text-xs font-semibold text-muted uppercase">Nome / Entity ID</th>
+                  <th className="px-3 py-2 text-xs font-semibold text-muted uppercase">Tipo</th>
+                  <th className="px-3 py-2 text-xs font-semibold text-muted uppercase">Status</th>
+                  <th className="px-3 py-2 text-xs font-semibold text-muted uppercase">Local</th>
+                  <th className="px-3 py-2 text-xs font-semibold text-muted uppercase">Visível</th>
+                  <th className="px-3 py-2 text-xs font-semibold text-muted uppercase">Ações</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((asset) => (
+                  <AssetRow
+                    key={asset.id}
+                    asset={asset}
+                    onEdit={(a) => { setEditTarget(a); setShowForm(true) }}
+                    onDelete={handleDelete}
+                    onRestore={handleRestore}
+                  />
+                ))}
+              </tbody>
+            </table>
+            <p className="text-xs text-muted px-3 py-2 border-t border-border">
+              {filtered.length} de {assets.length} ativos
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/dashboard/frontend/src/pages/AssetsAdmin.test.jsx
+++ b/src/dashboard/frontend/src/pages/AssetsAdmin.test.jsx
@@ -1,0 +1,188 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+import AssetsAdmin from "./AssetsAdmin";
+
+// Mock do hook useAssets
+vi.mock("../hooks/useAssets", () => ({
+  useAssets: vi.fn(),
+}));
+
+import { useAssets } from "../hooks/useAssets";
+
+const mockRefetch = vi.fn();
+
+function setupMockAssets(overrides = {}) {
+  useAssets.mockReturnValue({
+    assets: [],
+    sensorAssets: [],
+    cameraAssets: [],
+    droneAssets: [],
+    assetsLoading: false,
+    assetsError: null,
+    refetch: mockRefetch,
+    ...overrides,
+  });
+}
+
+describe("AssetsAdmin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupMockAssets();
+  });
+
+  it("renders the page title and empty state message", () => {
+    render(<AssetsAdmin />);
+    expect(screen.getByText("Cadastro de Ativos")).toBeInTheDocument();
+    expect(screen.getByText(/Nenhum ativo cadastrado/)).toBeInTheDocument();
+  });
+
+  it("shows loading state", () => {
+    setupMockAssets({ assetsLoading: true });
+    render(<AssetsAdmin />);
+    expect(screen.getByText("Carregando ativos...")).toBeInTheDocument();
+  });
+
+  it("shows error state", () => {
+    setupMockAssets({ assetsError: "Network error" });
+    render(<AssetsAdmin />);
+    expect(screen.getByText(/Erro: Network error/)).toBeInTheDocument();
+  });
+
+  it("renders asset rows when assets are loaded", () => {
+    setupMockAssets({
+      assets: [
+        {
+          id: "uuid-1",
+          name: "Sensor Porta",
+          entity_id: "binary_sensor.porta",
+          asset_type: "sensor",
+          status: "active",
+          is_active: true,
+          location: "entrada",
+        },
+        {
+          id: "uuid-2",
+          name: "Camera Entrada",
+          entity_id: "camera.entrada",
+          asset_type: "camera",
+          status: "active",
+          is_active: true,
+          location: null,
+        },
+      ],
+    });
+    render(<AssetsAdmin />);
+    expect(screen.getByText("Sensor Porta")).toBeInTheDocument();
+    expect(screen.getByText("Camera Entrada")).toBeInTheDocument();
+    expect(screen.getByText(/binary_sensor.porta/)).toBeInTheDocument();
+  });
+
+  it("shows the form when clicking Novo Ativo", () => {
+    render(<AssetsAdmin />);
+    const btn = screen.getByText("+ Novo Ativo");
+    fireEvent.click(btn);
+    expect(screen.getByText("Novo Ativo")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/ex: Sensor Porta Entrada/)).toBeInTheDocument();
+  });
+
+  it("closes the form when clicking Cancelar", () => {
+    render(<AssetsAdmin />);
+    fireEvent.click(screen.getByText("+ Novo Ativo"));
+    expect(screen.getByPlaceholderText(/ex: Sensor Porta Entrada/)).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Cancelar"));
+    expect(screen.queryByPlaceholderText(/ex: Sensor Porta Entrada/)).not.toBeInTheDocument();
+  });
+
+  it("shows admin key input field", () => {
+    render(<AssetsAdmin />);
+    expect(
+      screen.getByPlaceholderText(/Necessária para criar, editar ou desativar ativos/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows filter controls", () => {
+    render(<AssetsAdmin />);
+    expect(screen.getByPlaceholderText(/Buscar por nome ou entity_id/)).toBeInTheDocument();
+    expect(screen.getByText("Todos os tipos")).toBeInTheDocument();
+    expect(screen.getByText("Todos os status")).toBeInTheDocument();
+  });
+
+  it("calls refetch when clicking Atualizar", () => {
+    render(<AssetsAdmin />);
+    const btn = screen.getByText("↻ Atualizar");
+    fireEvent.click(btn);
+    expect(mockRefetch).toHaveBeenCalledOnce();
+  });
+
+  it("shows inactive asset row with reduced opacity", () => {
+    setupMockAssets({
+      assets: [
+        {
+          id: "uuid-1",
+          name: "Sensor Inativo",
+          entity_id: "binary_sensor.inativo",
+          asset_type: "sensor",
+          status: "inactive",
+          is_active: false,
+          location: null,
+        },
+      ],
+    });
+    render(<AssetsAdmin />);
+    expect(screen.getByText("Sensor Inativo")).toBeInTheDocument();
+    // Ativo inativo deve ter botão Restaurar, não Desativar
+    expect(screen.getByText("Restaurar")).toBeInTheDocument();
+    expect(screen.queryByText("Desativar")).not.toBeInTheDocument();
+  });
+
+  it("shows form validation error for missing admin key", async () => {
+    render(<AssetsAdmin />);
+    fireEvent.click(screen.getByText("+ Novo Ativo"));
+
+    const nameInput = screen.getByPlaceholderText(/ex: Sensor Porta Entrada/);
+    const entityIdInput = screen.getByPlaceholderText(/ex: binary_sensor.porta_entrada/);
+
+    fireEvent.change(nameInput, { target: { value: "Sensor Teste" } });
+    fireEvent.change(entityIdInput, { target: { value: "binary_sensor.teste" } });
+
+    fireEvent.click(screen.getByText("Cadastrar"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Informe a chave de administrador/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("filters assets by search term", () => {
+    setupMockAssets({
+      assets: [
+        {
+          id: "uuid-1",
+          name: "Sensor Porta",
+          entity_id: "binary_sensor.porta",
+          asset_type: "sensor",
+          status: "active",
+          is_active: true,
+          location: null,
+        },
+        {
+          id: "uuid-2",
+          name: "Camera Entrada",
+          entity_id: "camera.entrada",
+          asset_type: "camera",
+          status: "active",
+          is_active: true,
+          location: null,
+        },
+      ],
+    });
+    render(<AssetsAdmin />);
+
+    const searchInput = screen.getByPlaceholderText(/Buscar por nome ou entity_id/);
+    fireEvent.change(searchInput, { target: { value: "Camera" } });
+
+    expect(screen.getByText("Camera Entrada")).toBeInTheDocument();
+    expect(screen.queryByText("Sensor Porta")).not.toBeInTheDocument();
+  });
+});

--- a/src/dashboard/frontend/src/store/useStore.js
+++ b/src/dashboard/frontend/src/store/useStore.js
@@ -13,6 +13,11 @@ const useStore = create((set) => ({
   // Status de conexão WebSocket
   wsStatus: 'connecting', // connecting | connected | disconnected
 
+  // Catálogo de ativos (Issue #337)
+  assets: [],
+  assetsLoading: false,
+  assetsError: null,
+
   // Actions
   setStates: (states) => set({ states }),
 
@@ -35,6 +40,24 @@ const useStore = create((set) => ({
   setServices: (services) => set({ services }),
 
   setWsStatus: (wsStatus) => set({ wsStatus }),
+
+  // Assets actions
+  setAssets: (assets) => set({ assets }),
+  setAssetsLoading: (assetsLoading) => set({ assetsLoading }),
+  setAssetsError: (assetsError) => set({ assetsError }),
+
+  addAsset: (asset) =>
+    set((s) => ({ assets: [asset, ...s.assets] })),
+
+  updateAsset: (updatedAsset) =>
+    set((s) => ({
+      assets: s.assets.map((a) => (a.id === updatedAsset.id ? updatedAsset : a)),
+    })),
+
+  removeAsset: (assetId) =>
+    set((s) => ({
+      assets: s.assets.filter((a) => a.id !== assetId),
+    })),
 }))
 
 export default useStore

--- a/src/dashboard/frontend/src/store/useStore.test.js
+++ b/src/dashboard/frontend/src/store/useStore.test.js
@@ -7,6 +7,9 @@ describe("useStore actions", () => {
       alerts: [],
       services: {},
       wsStatus: "connecting",
+      assets: [],
+      assetsLoading: false,
+      assetsError: null,
     });
   });
 
@@ -38,5 +41,58 @@ describe("useStore actions", () => {
   it("sets services payload", () => {
     useStore.getState().setServices({ mqtt: "online" });
     expect(useStore.getState().services.mqtt).toBe("online");
+  });
+
+  // --- Testes de assets (Issue #337) ---
+
+  it("setAssets replaces the assets array", () => {
+    const assets = [{ id: "1", name: "Sensor A", asset_type: "sensor" }];
+    useStore.getState().setAssets(assets);
+    expect(useStore.getState().assets).toEqual(assets);
+  });
+
+  it("addAsset prepends a new asset", () => {
+    const existing = { id: "1", name: "Sensor A", asset_type: "sensor" };
+    useStore.setState({ assets: [existing] });
+
+    const newAsset = { id: "2", name: "Camera B", asset_type: "camera" };
+    useStore.getState().addAsset(newAsset);
+
+    const assets = useStore.getState().assets;
+    expect(assets[0]).toEqual(newAsset);
+    expect(assets[1]).toEqual(existing);
+  });
+
+  it("updateAsset replaces asset with matching id", () => {
+    const original = { id: "1", name: "Sensor A", status: "active" };
+    useStore.setState({ assets: [original] });
+
+    const updated = { id: "1", name: "Sensor A", status: "inactive" };
+    useStore.getState().updateAsset(updated);
+
+    expect(useStore.getState().assets[0].status).toBe("inactive");
+  });
+
+  it("removeAsset removes asset by id", () => {
+    const assets = [
+      { id: "1", name: "Sensor A" },
+      { id: "2", name: "Camera B" },
+    ];
+    useStore.setState({ assets });
+    useStore.getState().removeAsset("1");
+
+    expect(useStore.getState().assets).toHaveLength(1);
+    expect(useStore.getState().assets[0].id).toBe("2");
+  });
+
+  it("setAssetsLoading and setAssetsError manage loading state", () => {
+    useStore.getState().setAssetsLoading(true);
+    expect(useStore.getState().assetsLoading).toBe(true);
+
+    useStore.getState().setAssetsError("Network error");
+    expect(useStore.getState().assetsError).toBe("Network error");
+
+    useStore.getState().setAssetsLoading(false);
+    expect(useStore.getState().assetsLoading).toBe(false);
   });
 });


### PR DESCRIPTION
## Resumo

Implementa Issue #337 — interface completa de administração de ativos no dashboard.

### Novos componentes/páginas
- **`AssetsAdmin.jsx`**: CRUD completo com tabela, formulário, filtros e feedback
  - Lista ativos com filtro por tipo/status/busca textual
  - Formulário de criação/edição por tipo (sensor/camera/ugv/uav) com validação
  - Soft delete (Desativar) e restauração via botões por linha
  - Campo de Admin Key para operações de escrita (passado como X-Admin-Key)
  - Confirmação antes de desativar

- **`useAssets.js`**: hook que carrega /api/assets no mount, filtra por tipo
  e expõe `sensorAssets`, `cameraAssets`, `droneAssets`, `refetch`

### Componentes atualizados
- **`SensorGrid.jsx`**: usa catálogo dinâmico quando disponível, fallback para lista estática
- **`CameraGrid.jsx`**: usa catálogo dinâmico quando disponível, fallback para lista estática
- **`App.jsx`**: nova rota `/admin/assets`
- **`useStore.js`**: novo estado `assets` + actions (setAssets, addAsset, updateAsset, removeAsset, setAssetsLoading, setAssetsError)
- **`nginx.conf.template`**: injeta `X-API-Key` no proxy do backend (operador)

### Testes
- `AssetsAdmin.test.jsx`: 11 casos (empty/loading/error state, filtros, form, admin key)
- `useAssets.test.jsx`: 5 casos (fetch, error, filtros por tipo, refetch)
- `useStore.test.js`: atualizado com 5 novos casos de assets
- `CameraGrid.test.jsx`: atualizado com mock de useAssets

## Checklist
- [x] Usuário autorizado consegue cadastrar os 4 tipos de ativo
- [x] SensorGrid/CameraGrid leem do catálogo cadastrado (com fallback)
- [x] Formulários com validação e estados de erro
- [x] Admin key separada da operator key
- [x] Testes de componentes e hook
- [x] Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)