### PR TITLE
docs(qa): QA/Release — runbook, ADR, smoke tests E2E e docs API do catálogo de ativos (#340)

### DIFF
--- a/docs/API_DOCS.md
+++ b/docs/API_DOCS.md
@@ -2,7 +2,7 @@
 
 > Sistema de Home Security – Open Source / Open Hardware
 >
-> Versao: 1.0 | Data: 2026-02-18
+> Versao: 1.1 | Data: 2026-02-23 | Adicionado: Catálogo de Ativos e Trilha de Auditoria (Issues #336, #339)
 
 ---
 
@@ -15,7 +15,8 @@ O sistema utiliza APIs REST, WebSocket e MQTT para comunicacao entre componentes
 - **Formato**: JSON para APIs REST, JSON para MQTT payloads
 - **Autenticacao**:
   - Home Assistant: Bearer token (Long-Lived Access Token)
-  - Dashboard API: `X-API-Key` ou Bearer
+  - Dashboard API (operador): `X-API-Key` header ou `Authorization: Bearer <key>`
+  - Dashboard API (admin): `X-Admin-Key` header (necessário para CRUD de ativos)
   - MQTT: usuario/senha
 - **Codigos de erro**: Padrao HTTP para REST APIs
 
@@ -314,6 +315,189 @@ websocat \
 
 ---
 
+## 8. Catalogo de Ativos (`/api/assets`)
+
+**Base URL**: `http://<HOST>:8000`
+**Autenticacao leitura**: `X-API-Key: <DASHBOARD_API_KEY>` (operador)
+**Autenticacao escrita**: `X-API-Key` + `X-Admin-Key: <DASHBOARD_ADMIN_KEY>` (admin)
+
+### Tipos de ativo
+
+| `asset_type` | Descricao |
+|-------------|-----------|
+| `sensor` | Sensor Zigbee (porta, janela, PIR) |
+| `camera` | Camera IP / Frigate |
+| `ugv` | Drone terrestre (UGV) |
+| `uav` | Drone aereo (UAV) |
+
+### Status possiveis
+
+| `status` | Descricao |
+|----------|-----------|
+| `active` | Ativo e operacional |
+| `inactive` | Desativado (soft delete) |
+| `offline` | Sem comunicacao |
+| `maintenance` | Em manutencao |
+
+### Endpoints
+
+| Metodo | Endpoint | Auth | Descricao |
+|--------|----------|------|-----------|
+| `GET` | `/api/assets` | Operador | Lista ativos com paginacao e filtros |
+| `GET` | `/api/assets/{asset_id}` | Operador | Detalhes de um ativo |
+| `POST` | `/api/assets` | Admin | Cadastrar novo ativo |
+| `PUT` | `/api/assets/{asset_id}` | Admin | Atualizar ativo |
+| `DELETE` | `/api/assets/{asset_id}` | Admin | Soft-delete (marca `is_active=False`) |
+| `POST` | `/api/assets/{asset_id}/restore` | Admin | Reativar ativo desativado |
+
+### Filtros para `GET /api/assets`
+
+| Parametro | Tipo | Descricao |
+|-----------|------|-----------|
+| `asset_type` | string | Filtrar por tipo (`sensor`, `camera`, `ugv`, `uav`) |
+| `status` | string | Filtrar por status |
+| `is_active` | bool | `true` retorna apenas ativos; `false` apenas inativos |
+| `search` | string | Busca parcial em `name`, `entity_id`, `location` |
+| `page` | int | Pagina (padrao: 1) |
+| `page_size` | int | Itens por pagina (padrao: 50, max: 200) |
+
+**Exemplo — listar sensores ativos:**
+
+```bash
+curl -H "X-API-Key: ${DASHBOARD_API_KEY}" \
+  "http://localhost:8000/api/assets?asset_type=sensor&is_active=true"
+```
+
+```json
+{
+  "items": [
+    {
+      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "asset_type": "sensor",
+      "name": "Sensor Porta Entrada",
+      "entity_id": "binary_sensor.porta_entrada",
+      "location": "entrada",
+      "description": null,
+      "status": "active",
+      "is_active": true,
+      "config_json": null,
+      "created_at": "2026-02-23T10:00:00+00:00",
+      "updated_at": "2026-02-23T10:00:00+00:00"
+    }
+  ],
+  "total": 1,
+  "page": 1,
+  "page_size": 50,
+  "pages": 1
+}
+```
+
+**Exemplo — cadastrar ativo (requer admin key):**
+
+```bash
+curl -X POST http://localhost:8000/api/assets \
+  -H "X-API-Key: ${DASHBOARD_API_KEY}" \
+  -H "X-Admin-Key: ${DASHBOARD_ADMIN_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "asset_type": "sensor",
+    "name": "Sensor Janela Sala",
+    "entity_id": "binary_sensor.janela_sala",
+    "location": "sala",
+    "description": "Sensor magnetico de janela"
+  }'
+```
+
+**Resposta (201 Created):**
+
+```json
+{
+  "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  "asset_type": "sensor",
+  "name": "Sensor Janela Sala",
+  "entity_id": "binary_sensor.janela_sala",
+  "location": "sala",
+  "description": "Sensor magnetico de janela",
+  "status": "active",
+  "is_active": true,
+  "config_json": null,
+  "created_at": "2026-02-23T10:05:00+00:00",
+  "updated_at": "2026-02-23T10:05:00+00:00"
+}
+```
+
+> **Nota de seguranca**: respostas nunca incluem `credential_ref` nem dados sensíveis de `asset_credentials`.
+> Quando `DASHBOARD_ADMIN_KEY` nao esta configurado, operacoes de escrita retornam **503**.
+
+---
+
+## 9. Trilha de Auditoria (`/api/audit`)
+
+**Autenticacao**: `X-API-Key` (operador) — somente leitura
+
+| Metodo | Endpoint | Descricao |
+|--------|----------|-----------|
+| `GET` | `/api/audit` | Lista registros de auditoria com filtros |
+| `GET` | `/api/audit/export` | Exportar trilha (JSON ou CSV) |
+
+### Filtros para `GET /api/audit`
+
+| Parametro | Tipo | Descricao |
+|-----------|------|-----------|
+| `asset_id` | UUID | Filtrar por ativo |
+| `action` | string | Filtrar por acao (`create`, `update`, `delete`, `restore`) |
+| `actor` | string | Filtrar por autor da operacao |
+| `since` | ISO datetime | Registros a partir de data |
+| `until` | ISO datetime | Registros ate data |
+| `page` | int | Pagina (padrao: 1) |
+| `page_size` | int | Itens por pagina (padrao: 50, max: 200) |
+
+**Exemplo — listar auditoria de um ativo:**
+
+```bash
+curl -H "X-API-Key: ${DASHBOARD_API_KEY}" \
+  "http://localhost:8000/api/audit?asset_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+```
+
+```json
+{
+  "items": [
+    {
+      "id": 1,
+      "asset_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "action": "create",
+      "before_json": null,
+      "after_json": "{\"name\": \"Sensor Porta Entrada\", \"status\": \"active\"}",
+      "actor": "admin",
+      "actor_ip": "192.168.10.5",
+      "created_at": "2026-02-23T10:00:00+00:00"
+    }
+  ],
+  "total": 1,
+  "page": 1,
+  "page_size": 50,
+  "pages": 1
+}
+```
+
+**Exportar trilha de auditoria:**
+
+```bash
+# JSON
+curl -H "X-API-Key: ${DASHBOARD_API_KEY}" \
+  "http://localhost:8000/api/audit/export?format=json" \
+  -o audit_export.json
+
+# CSV
+curl -H "X-API-Key: ${DASHBOARD_API_KEY}" \
+  "http://localhost:8000/api/audit/export?format=csv" \
+  -o audit_export.csv
+```
+
+Resposta inclui header `Content-Disposition: attachment; filename="audit_YYYYMMDD_HHMMSS.{format}"`.
+
+---
+
 ## Referencias
 
 - [Home Assistant REST API](https://developers.home-assistant.io/docs/api/rest)
@@ -321,3 +505,5 @@ websocat \
 - [Frigate HTTP API](https://docs.frigate.video/integrations/api)
 - [Zigbee2MQTT MQTT Topics](https://www.zigbee2mqtt.io/guide/usage/mqtt_topics_and_messages.html)
 - [Mosquitto Configuration](https://mosquitto.org/man/mosquitto-conf-5.html)
+- [ADR 011 — Catálogo Dinâmico de Ativos](adr/011-adoption-assets-catalog.md)
+- [Runbook de Rollout do Catálogo](ASSETS_CATALOG_ROLLOUT_RUNBOOK.md)

--- a/docs/ASSETS_CATALOG_ROLLOUT_RUNBOOK.md
+++ b/docs/ASSETS_CATALOG_ROLLOUT_RUNBOOK.md
@@ -1,0 +1,172 @@
+# Runbook: Rollout e Rollback do Catálogo de Ativos
+
+> Versão: 1.0 | Data: 2026-02-23 | Issues: #334–#340
+
+---
+
+## 1. Pré-requisitos
+
+- [ ] `DASHBOARD_ADMIN_KEY` configurado em todos os ambientes de destino
+- [ ] Banco de dados acessível e migração prévia testada em staging
+- [ ] Backup do banco realizado (`scripts/backup.sh`) antes do deploy
+- [ ] Pipeline CI verde (todos os testes passando)
+- [ ] Stack do docker-compose ou K8s respondendo
+
+---
+
+## 2. Plano de Deploy Progressivo
+
+### 2.1 Fase 1 — Banco de Dados (migration)
+
+```bash
+# Aplicar migração 20260223_0003 (non-destructive, sem downtime)
+alembic upgrade 20260223_0003
+
+# Verificar que as 3 tabelas foram criadas
+psql -U dashboard_user -d homedb -c "\dt dashboard.*"
+# Esperado: assets, asset_credentials, asset_audit (além das existentes)
+
+# Verificar backfill de device_positions -> assets
+psql -U dashboard_user -d homedb -c "SELECT count(*) FROM dashboard.assets;"
+```
+
+### 2.2 Fase 2 — Backend API
+
+```bash
+# Atualizar container/pod do backend
+docker compose -f src/docker-compose.yml up -d --no-deps dashboard-api
+
+# Smoke check dos novos endpoints
+curl -s -o /dev/null -w "%{http_code}" \
+  -H "X-API-Key: $DASHBOARD_API_KEY" \
+  http://localhost:8000/api/assets
+# Esperado: 200
+
+# Verificar que /api/map/devices ainda responde
+curl -s -H "X-API-Key: $DASHBOARD_API_KEY" \
+  http://localhost:8000/api/map/devices | python3 -c "import sys,json; d=json.load(sys.stdin); print(f'{len(d)} devices')"
+```
+
+### 2.3 Fase 3 — Frontend
+
+```bash
+# Atualizar container do frontend
+docker compose -f src/docker-compose.yml up -d --no-deps dashboard-frontend
+
+# Verificar que a rota admin está acessível
+curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/admin/assets
+# Esperado: 200 (SPA fallback para index.html)
+```
+
+### 2.4 Fase 4 — Smoke Test de Fluxo Completo
+
+```bash
+# 1. Cadastrar sensor
+ASSET_ID=$(curl -s -X POST http://localhost:8000/api/assets \
+  -H "X-API-Key: $DASHBOARD_API_KEY" \
+  -H "X-Admin-Key: $DASHBOARD_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"asset_type":"sensor","name":"Smoke Test Sensor","entity_id":"test.smoke_sensor"}' \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['id'])")
+
+echo "Asset criado: $ASSET_ID"
+
+# 2. Verificar no catálogo
+curl -s -H "X-API-Key: $DASHBOARD_API_KEY" \
+  "http://localhost:8000/api/assets/$ASSET_ID" | python3 -m json.tool
+
+# 3. Verificar no mapa
+curl -s -H "X-API-Key: $DASHBOARD_API_KEY" \
+  http://localhost:8000/api/map/devices | python3 -c \
+  "import sys,json; d=json.load(sys.stdin); print('OK' if any(x.get('entity_id')=='test.smoke_sensor' for x in d) else 'MISSING')"
+
+# 4. Verificar trilha de auditoria
+curl -s -H "X-API-Key: $DASHBOARD_API_KEY" \
+  "http://localhost:8000/api/audit?asset_id=$ASSET_ID" | python3 -m json.tool
+
+# 5. Limpar ativo de smoke test
+curl -s -X DELETE \
+  -H "X-API-Key: $DASHBOARD_API_KEY" \
+  -H "X-Admin-Key: $DASHBOARD_ADMIN_KEY" \
+  "http://localhost:8000/api/assets/$ASSET_ID"
+```
+
+---
+
+## 3. Checklist de Observabilidade Pós-deploy
+
+| Verificação | Comando | Esperado |
+|-------------|---------|----------|
+| Backend health | `GET /health` | `{"status":"ok"}` |
+| Assets API | `GET /api/assets` | 200, JSON com `items` |
+| Audit API | `GET /api/audit` | 200, JSON com `items` |
+| Map devices | `GET /api/map/devices` | 200, lista de devices |
+| Admin RBAC | `POST /api/assets` sem X-Admin-Key | 403 ou 503 |
+| Logs backend | `docker logs dashboard-api` | Sem traceback |
+| Logs frontend | `docker logs dashboard-frontend` | Sem erro nginx |
+
+---
+
+## 4. Rollback
+
+### 4.1 Rollback rápido — reverter container
+
+```bash
+# Reverter imagens para versão anterior (tag anterior no registry)
+docker compose -f src/docker-compose.yml up -d --no-deps \
+  --pull never dashboard-api dashboard-frontend
+```
+
+### 4.2 Rollback completo — incluindo migração de banco
+
+> **Atenção**: o rollback de migração remove as tabelas `assets`, `asset_credentials`
+> e `asset_audit`. Dados cadastrados serão perdidos. Execute apenas se necessário.
+
+```bash
+# Reverter apenas a migration 0003
+alembic downgrade 20260219_0002
+
+# Verificar que tabelas assets foram removidas
+psql -U dashboard_user -d homedb -c "\dt dashboard.*"
+# Não deve aparecer: assets, asset_credentials, asset_audit
+
+# Reverter containers backend e frontend
+docker compose -f src/docker-compose.yml up -d --no-deps \
+  --pull never dashboard-api dashboard-frontend
+```
+
+### 4.3 Validar rollback
+
+```bash
+# /api/assets deve retornar 404 após rollback completo do backend
+curl -s -o /dev/null -w "%{http_code}" \
+  -H "X-API-Key: $DASHBOARD_API_KEY" http://localhost:8000/api/assets
+# Esperado: 404
+
+# /api/map/devices deve continuar funcionando (usa device_positions legadas)
+curl -s -o /dev/null -w "%{http_code}" \
+  -H "X-API-Key: $DASHBOARD_API_KEY" http://localhost:8000/api/map/devices
+# Esperado: 200
+```
+
+---
+
+## 5. Estratégia de Feature Flag (opcional)
+
+Para deploy gradual sem rollback de banco, pode-se usar a variável de ambiente:
+
+```bash
+# Desativar DASHBOARD_ADMIN_KEY = desabilita operações admin sem reverter código
+DASHBOARD_ADMIN_KEY=""  # admin key vazia → endpoints admin retornam 503
+
+# Isso mantém a API de leitura (/api/assets GET) funcional enquanto bloqueia escrita
+```
+
+---
+
+## 6. Contato em caso de incidente
+
+1. Verificar logs: `docker logs dashboard-api --tail 100`
+2. Verificar alertas no dashboard de observabilidade
+3. Se banco inacessível: consultar `docs/POSTGRES_BACKUP_RESTORE_RUNBOOK.md`
+4. Se problema crítico de segurança: seguir `docs/INCIDENT_RESPONSE.md`

--- a/docs/adr/011-adoption-assets-catalog.md
+++ b/docs/adr/011-adoption-assets-catalog.md
@@ -1,0 +1,46 @@
+# ADR 011 — Catálogo Dinâmico de Ativos no Dashboard
+
+**Data**: 2026-02-23
+**Status**: Aceito
+**Issues**: #334, #335, #336, #337, #338, #339, #340
+
+---
+
+## Contexto
+
+O dashboard original usava listas hardcoded em `SensorGrid.jsx`, `CameraGrid.jsx` e `config.py` para determinar quais dispositivos exibir. Isso criava fricção operacional ao adicionar novos sensores ou câmeras (requeria deploy de código), além de impossibilitar rastreabilidade de mudanças.
+
+## Decisão
+
+Implementar um catálogo dinâmico de ativos com:
+1. **Modelo de dados normalizado** (`dashboard.assets` + `asset_credentials` + `asset_audit`) com UUID pk, constraint de tipo e status
+2. **API CRUD REST** (`/api/assets`) com paginação, busca e soft delete
+3. **RBAC por nível de operação**: leitura via `X-API-Key`, escrita via `X-Admin-Key` separado
+4. **Trilha de auditoria transacional** em toda operação de escrita (before/after JSON + actor + IP)
+5. **Frontend com fallback**: SensorGrid/CameraGrid usam catálogo dinâmico, com fallback para listas estáticas se vazio
+6. **Migração não-destrutiva**: backfill de `device_positions` → `assets` no upgrade, rollback seguro no downgrade
+
+## Alternativas consideradas
+
+- **Configuração via arquivo YAML**: rejeitado — sem trilha de auditoria, requer deploy para mudanças
+- **Integração direta com Home Assistant entity registry**: rejeitado — acoplamento forte com HA, não suporta ativos não-HA (câmeras offline, sensores de terceiros)
+- **CRUD no frontend sem backend**: rejeitado — sem persistência, sem auditoria, sem RBAC
+
+## Consequências
+
+**Positivas**:
+- Cadastro de ativos sem deploy de código
+- Auditoria completa de quem/quando/o-que mudou
+- RBAC separado: operadores podem monitorar, só admins cadastram
+- SensorGrid/CameraGrid passam a ser data-driven (não hardcoded)
+
+**Negativas**:
+- Dependência de `DASHBOARD_ADMIN_KEY` configurado para operações de escrita
+- Curva de aprendizado para operadores (nova UI em `/admin/assets`)
+- Backfill inicial pode criar ativos duplicados se `device_positions` já contiver dados
+
+## Referências
+
+- [SECURITY.md](../../SECURITY.md) — hardening e RBAC
+- [ASSETS_CATALOG_ROLLOUT_RUNBOOK.md](../ASSETS_CATALOG_ROLLOUT_RUNBOOK.md) — deploy e rollback
+- [API_DOCS.md](../API_DOCS.md) — documentação de endpoints

--- a/tests/backend/test_assets_e2e_smoke_contract.py
+++ b/tests/backend/test_assets_e2e_smoke_contract.py
@@ -1,0 +1,325 @@
+"""Smoke tests E2E de fluxo completo do catálogo de ativos — Issue #340.
+
+Estes testes validam o fluxo cadastro → persistência → exibição → auditoria
+usando mocks de sessão para simular comportamento integrado end-to-end.
+"""
+
+import json
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from fastapi import Depends, FastAPI
+
+from app.db.session import get_db
+from app.routers import alerts, assets as assets_router, audit as audit_router
+from app.security import require_api_key
+
+OPERATOR_KEY = "test-api-key"
+ADMIN_KEY = "test-admin-key"
+TEST_BASE_URL = "http://testserver"
+
+
+class _FullSmokeSession:
+    """Sessão de banco que simula o estado completo do sistema em E2E."""
+
+    def __init__(self):
+        self._assets: dict[str, MagicMock] = {}
+        self._audit_trail: list[MagicMock] = []
+        self.flushed = []
+        self.committed = []
+
+    def _make_audit_record(self, asset_id, action, before, after, actor, actor_ip):
+        record = MagicMock()
+        record.id = len(self._audit_trail) + 1
+        record.asset_id = asset_id
+        record.action = action
+        record.before_json = json.dumps(before, default=str) if before else None
+        record.after_json = json.dumps(after, default=str) if after else None
+        record.actor = actor
+        record.actor_ip = actor_ip
+        record.created_at = datetime.now(timezone.utc)
+        return record
+
+    async def execute(self, stmt):
+        # Retorna resultado baseado no conteúdo da query (simplificado)
+        result = MagicMock()
+        scalars = MagicMock()
+        scalars.all.return_value = list(self._assets.values())
+        scalars.scalar_one.return_value = len(self._assets)
+        scalars.scalar_one_or_none.return_value = (
+            list(self._assets.values())[0] if self._assets else None
+        )
+        result.scalars.return_value = scalars
+        result.scalar_one.return_value = len(self._assets)
+        result.scalar_one_or_none.return_value = (
+            list(self._assets.values())[0] if self._assets else None
+        )
+        return result
+
+    def add(self, obj):
+        from app.db.models import Asset, AssetAudit
+
+        if isinstance(obj, Asset):
+            self._assets[str(obj.id)] = obj
+        elif isinstance(obj, AssetAudit):
+            self._audit_trail.append(obj)
+
+    async def flush(self):
+        self.flushed.append(True)
+
+    async def commit(self):
+        self.committed.append(True)
+
+    async def refresh(self, obj):
+        pass
+
+
+def _build_smoke_app():
+    session = _FullSmokeSession()
+
+    async def _override():
+        yield session
+
+    app = FastAPI()
+    app.include_router(assets_router.router, dependencies=[Depends(require_api_key)])
+    app.include_router(audit_router.router, dependencies=[Depends(require_api_key)])
+    app.include_router(alerts.router, dependencies=[Depends(require_api_key)])
+    app.dependency_overrides[get_db] = _override
+    return app, session
+
+
+# ---------------------------------------------------------------------------
+# Fluxo completo: cadastro → auditoria
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_smoke_create_asset_generates_audit_event():
+    """Smoke: criação de ativo deve gerar evento de auditoria."""
+    app, session = _build_smoke_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        resp = await client.post(
+            "/api/assets",
+            headers={"X-API-Key": OPERATOR_KEY, "X-Admin-Key": ADMIN_KEY},
+            json={
+                "asset_type": "sensor",
+                "name": "Sensor Porta Smoke",
+                "entity_id": "binary_sensor.porta_smoke",
+                "location": "entrada",
+            },
+        )
+
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["entity_id"] == "binary_sensor.porta_smoke"
+    assert data["asset_type"] == "sensor"
+    assert data["is_active"] is True
+
+    # Verificar que foi adicionado ao "banco"
+    assert len(session._assets) == 1
+    # Verificar que auditoria foi gerada
+    assert len(session._audit_trail) == 1
+    assert session._audit_trail[0].action == "create"
+
+
+@pytest.mark.anyio
+async def test_smoke_asset_response_excludes_credentials():
+    """Smoke: resposta de ativo nunca inclui campos sensíveis."""
+    app, session = _build_smoke_app()
+
+    # Pré-popular com um ativo
+    from app.db.models import Asset
+    asset = Asset(
+        id=uuid.uuid4(),
+        asset_type="camera",
+        name="Camera Smoke",
+        entity_id="camera.smoke",
+        status="active",
+        is_active=True,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    session._assets[str(asset.id)] = asset
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        resp = await client.get(
+            f"/api/assets/{asset.id}",
+            headers={"X-API-Key": OPERATOR_KEY},
+        )
+
+    assert resp.status_code == 200
+    body = resp.text
+    assert "credential" not in body.lower()
+    assert "password" not in body.lower()
+    assert "secret" not in body.lower()
+
+
+@pytest.mark.anyio
+async def test_smoke_soft_delete_marks_inactive():
+    """Smoke: DELETE soft-delete marca is_active=False sem remover do banco."""
+    app, session = _build_smoke_app()
+
+    from app.db.models import Asset
+    asset = Asset(
+        id=uuid.uuid4(),
+        asset_type="sensor",
+        name="Sensor Para Deletar",
+        entity_id="binary_sensor.para_deletar",
+        status="active",
+        is_active=True,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    session._assets[str(asset.id)] = asset
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        resp = await client.delete(
+            f"/api/assets/{asset.id}",
+            headers={"X-API-Key": OPERATOR_KEY, "X-Admin-Key": ADMIN_KEY},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "deactivated"
+
+    # Verificar que auditoria de delete foi gerada
+    delete_audits = [a for a in session._audit_trail if a.action == "delete"]
+    assert len(delete_audits) == 1
+
+
+@pytest.mark.anyio
+async def test_smoke_restore_reactivates_asset():
+    """Smoke: restore reativa ativo desativado."""
+    app, session = _build_smoke_app()
+
+    from app.db.models import Asset
+    asset = Asset(
+        id=uuid.uuid4(),
+        asset_type="ugv",
+        name="UGV Inativo",
+        entity_id="device.ugv_inativo",
+        status="inactive",
+        is_active=False,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    session._assets[str(asset.id)] = asset
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        resp = await client.post(
+            f"/api/assets/{asset.id}/restore",
+            headers={"X-API-Key": OPERATOR_KEY, "X-Admin-Key": ADMIN_KEY},
+        )
+
+    assert resp.status_code == 200
+    # Verificar auditoria de restore
+    restore_audits = [a for a in session._audit_trail if a.action == "restore"]
+    assert len(restore_audits) == 1
+
+
+@pytest.mark.anyio
+async def test_smoke_audit_export_returns_attachment():
+    """Smoke: exportação de auditoria retorna Content-Disposition attachment."""
+    app, session = _build_smoke_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        for fmt in ("json", "csv"):
+            resp = await client.get(
+                f"/api/audit/export?format={fmt}",
+                headers={"X-API-Key": OPERATOR_KEY},
+            )
+            assert resp.status_code == 200, f"Falhou para format={fmt}"
+            assert "attachment" in resp.headers.get("content-disposition", ""), (
+                f"Content-Disposition ausente para format={fmt}"
+            )
+
+
+@pytest.mark.anyio
+async def test_smoke_rbac_create_blocked_without_admin_key():
+    """Smoke: criação de ativo bloqueada sem admin key."""
+    app, session = _build_smoke_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        # Sem X-Admin-Key
+        resp = await client.post(
+            "/api/assets",
+            headers={"X-API-Key": OPERATOR_KEY},  # operator key, sem admin key
+            json={
+                "asset_type": "sensor",
+                "name": "Sensor Não Autorizado",
+                "entity_id": "binary_sensor.nao_autorizado",
+            },
+        )
+    assert resp.status_code in (403, 503), (
+        f"Esperado 403 ou 503, obteve {resp.status_code}"
+    )
+    # Ativo não deve ter sido criado
+    assert len(session._assets) == 0
+
+
+@pytest.mark.anyio
+async def test_smoke_list_assets_no_auth_returns_403():
+    """Smoke: listagem sem autenticação retorna 403."""
+    app, session = _build_smoke_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        resp = await client.get("/api/assets")
+    assert resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_smoke_audit_list_no_auth_returns_403():
+    """Smoke: trilha de auditoria sem autenticação retorna 403."""
+    app, session = _build_smoke_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        resp = await client.get("/api/audit")
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Regressão: endpoints existentes não devem quebrar
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_smoke_no_regression_alerts_endpoint():
+    """Regressão: /api/alerts continua funcionando após adição do catálogo."""
+    app, session = _build_smoke_app()
+
+    from app.db.models import Alert
+    mock_alert = MagicMock(spec=Alert)
+    mock_alert.id = 1
+    mock_alert.timestamp = datetime.now(timezone.utc)
+    mock_alert.entity_id = "binary_sensor.porta"
+    mock_alert.event_type = "state_changed"
+    mock_alert.old_state = "off"
+    mock_alert.new_state = "on"
+    mock_alert.severity = "warning"
+    mock_alert.message = None
+
+    # Sobrescrever execute temporariamente para retornar o alerta
+    original_execute = session.execute
+
+    async def _exec_alerts(stmt):
+        result = MagicMock()
+        scalars = MagicMock()
+        scalars.all.return_value = [mock_alert]
+        result.scalars.return_value = scalars
+        return result
+
+    session.execute = _exec_alerts
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+        resp = await client.get("/api/alerts", headers={"X-API-Key": OPERATOR_KEY})
+
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)


### PR DESCRIPTION
## Resumo

Implementação completa da issue #340 — plano de QA/Release para o catálogo dinâmico de ativos.

## Mudanças

- **`docs/ASSETS_CATALOG_ROLLOUT_RUNBOOK.md`**: runbook de deploy progressivo em 4 fases (migration → backend → frontend → smoke tests manuais), com checklist de observabilidade e procedimentos de rollback (container e migração)
- **`docs/adr/011-adoption-assets-catalog.md`**: ADR documentando decisão de catálogo dinâmico vs configuração YAML vs integração direta com Home Assistant
- **`docs/API_DOCS.md`**: seções 8 (`/api/assets`) e 9 (`/api/audit`) com endpoints, schemas, filtros de busca, exemplos `curl` e notas de segurança; versão 1.1
- **`tests/backend/test_assets_e2e_smoke_contract.py`**: 9 smoke tests E2E cobrindo fluxo completo: create→audit, exclusão de campos sensíveis, soft-delete, restore, exportação de auditoria, RBAC sem admin key, auth obrigatória, e regressão de `/api/alerts`

## Plano de teste

- [x] Smoke tests E2E adicionados em `tests/backend/test_assets_e2e_smoke_contract.py`
- [x] Runbook de smoke test manual incluído no runbook (Fase 4)
- [x] Checklist de observabilidade pós-deploy documentado
- [x] Procedures de rollback (rápido e completo) documentados

## Issues relacionadas

Closes #340
Relacionado a #334 #335 #336 #337 #338 #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)