### PR TITLE
feat(dashboard): menu operacional na home com atalhos de cadastros

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ Para testar o sistema em seu computador ou servidor de desenvolvimento:
 4. Acesse:
    - Home Assistant: `http://localhost:8123`
    - Frigate NVR: `http://localhost:5000`
+   - Dashboard Operacional: `http://localhost:3000`
+
+### Navegação do Dashboard
+
+- `/` — dashboard completo com **Menu Operacional** (atalhos para admin e cadastros).
+- `/admin/assets` — administração de ativos (CRUD de sensores, câmeras, UGV e UAV).
+- `/admin/assets?type=sensor|camera|ugv|uav` — cadastro com filtro inicial por tipo.
+- `/simplified` — modo kiosk/simplificado para monitor dedicado.
 
 > 📘 **Guia completo**: Veja [src/docs/QUICK_START.md](src/docs/QUICK_START.md)
 

--- a/src/dashboard/frontend/eslint.config.js
+++ b/src/dashboard/frontend/eslint.config.js
@@ -14,6 +14,8 @@ export default [
         document: "readonly",
         fetch: "readonly",
         WebSocket: "readonly",
+        URLSearchParams: "readonly",
+        FileReader: "readonly",
         setInterval: "readonly",
         clearInterval: "readonly",
         setTimeout: "readonly",

--- a/src/dashboard/frontend/src/App.test.jsx
+++ b/src/dashboard/frontend/src/App.test.jsx
@@ -23,7 +23,7 @@ class MockWebSocket {
 }
 
 function mockFetchForDashboard() {
-  global.fetch = vi.fn(async (url, options = {}) => {
+  global.fetch = vi.fn(async (url) => {
     if (url === "/api/alerts?limit=30") {
       return { ok: true, json: async () => [] };
     }
@@ -96,6 +96,12 @@ describe("App routing and dashboard", () => {
     expect(await screen.findByText(/HOME SECURITY/i)).toBeInTheDocument();
     expect(screen.getByText("Mapa Operacional")).toBeInTheDocument();
     expect(screen.getByText("Drones")).toBeInTheDocument();
+    expect(screen.getByText("Menu Operacional")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Admin de Ativos/i })).toHaveAttribute("href", "/admin/assets");
+    expect(screen.getByRole("link", { name: /Cadastro de Sensores/i })).toHaveAttribute("href", "/admin/assets?type=sensor");
+    expect(screen.getByRole("link", { name: /Cadastro de Câmeras/i })).toHaveAttribute("href", "/admin/assets?type=camera");
+    expect(screen.getByRole("link", { name: /Cadastro UGV/i })).toHaveAttribute("href", "/admin/assets?type=ugv");
+    expect(screen.getByRole("link", { name: /Cadastro UAV/i })).toHaveAttribute("href", "/admin/assets?type=uav");
 
     fireEvent.click(screen.getAllByText("Start Patrol")[0]);
     await waitFor(() =>

--- a/src/dashboard/frontend/src/components/CameraGrid.test.jsx
+++ b/src/dashboard/frontend/src/components/CameraGrid.test.jsx
@@ -1,10 +1,11 @@
 import { render, screen } from "@testing-library/react";
 import { vi } from "vitest";
 import CameraGrid from "./CameraGrid";
+import { useAssets } from "../hooks/useAssets";
 
 // Mock do hook useAssets para isolar o componente
 vi.mock("../hooks/useAssets", () => ({
-  useAssets: () => ({
+  useAssets: vi.fn(() => ({
     cameraAssets: [],
     sensorAssets: [],
     droneAssets: [],
@@ -12,7 +13,7 @@ vi.mock("../hooks/useAssets", () => ({
     assetsLoading: false,
     assetsError: null,
     refetch: vi.fn(),
-  }),
+  })),
 }));
 
 describe("CameraGrid", () => {
@@ -26,7 +27,7 @@ describe("CameraGrid", () => {
   });
 
   it("renders dynamic cameras when assets loaded", () => {
-    vi.mocked(require("../hooks/useAssets").useAssets).mockReturnValueOnce({
+    vi.mocked(useAssets).mockReturnValueOnce({
       cameraAssets: [
         { entity_id: "cam_frente", name: "Frente", asset_type: "camera", is_active: true },
         { entity_id: "cam_quintal", name: "Quintal", asset_type: "camera", is_active: true },

--- a/src/dashboard/frontend/src/components/QuickActionsMenu.jsx
+++ b/src/dashboard/frontend/src/components/QuickActionsMenu.jsx
@@ -1,0 +1,30 @@
+import { Link } from 'react-router-dom'
+
+const LINKS = [
+  { to: '/admin/assets', label: 'Admin de Ativos', description: 'Gestão completa de sensores, câmeras e drones.' },
+  { to: '/admin/assets?type=sensor', label: 'Cadastro de Sensores', description: 'Abrir cadastro já filtrado para sensores.' },
+  { to: '/admin/assets?type=camera', label: 'Cadastro de Câmeras', description: 'Abrir cadastro já filtrado para câmeras.' },
+  { to: '/admin/assets?type=ugv', label: 'Cadastro UGV', description: 'Abrir cadastro já filtrado para drones terrestres.' },
+  { to: '/admin/assets?type=uav', label: 'Cadastro UAV', description: 'Abrir cadastro já filtrado para drones aéreos.' },
+  { to: '/simplified', label: 'Modo Kiosk', description: 'Tela simplificada para monitor dedicado.' },
+]
+
+export default function QuickActionsMenu() {
+  return (
+    <div className="card flex flex-col gap-2">
+      <h2 className="text-xs font-semibold uppercase tracking-wider text-muted">Menu Operacional</h2>
+      <div className="grid gap-2">
+        {LINKS.map((link) => (
+          <Link
+            key={link.to}
+            to={link.to}
+            className="block rounded border border-border bg-surface px-2 py-2 hover:border-accent/50 hover:bg-accent/5 transition-colors"
+          >
+            <p className="text-sm font-medium text-primary">{link.label}</p>
+            <p className="text-xs text-muted">{link.description}</p>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/dashboard/frontend/src/components/SensorGrid.jsx
+++ b/src/dashboard/frontend/src/components/SensorGrid.jsx
@@ -11,15 +11,6 @@ const STATIC_SENSORS = [
   { id: 'binary_sensor.zigbee2mqtt_connection_state', label: 'Zigbee', icon: '📡' },
 ]
 
-const SENSOR_TYPE_ICONS = {
-  pir: '👁',
-  door: '🚪',
-  window: '🪟',
-  smoke: '🔥',
-  motion: '👁',
-  zigbee: '📡',
-}
-
 function getSensorIcon(asset) {
   const lower = (asset.entity_id + asset.name).toLowerCase()
   if (lower.includes('porta') || lower.includes('door')) return '🚪'

--- a/src/dashboard/frontend/src/pages/AssetsAdmin.jsx
+++ b/src/dashboard/frontend/src/pages/AssetsAdmin.jsx
@@ -2,7 +2,8 @@
  * Página de Administração de Ativos — Issue #337.
  * Permite listar, cadastrar, editar e desativar sensores, câmeras, UGV e UAV.
  */
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import useStore from '../store/useStore'
 import { useAssets } from '../hooks/useAssets'
 
@@ -277,16 +278,23 @@ function AssetRow({ asset, onEdit, onDelete, onRestore }) {
 // ---------------------------------------------------------------------------
 export default function AssetsAdmin() {
   const { assets, assetsLoading, assetsError, refetch } = useAssets()
-  const { addAsset, updateAsset, removeAsset } = useStore()
+  const { addAsset, updateAsset } = useStore()
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const typeParam = (searchParams.get('type') || '').toLowerCase()
+  const initialType = Object.hasOwn(ASSET_TYPE_LABELS, typeParam) ? typeParam : ''
 
   const [showForm, setShowForm] = useState(false)
   const [editTarget, setEditTarget] = useState(null)
   const [adminKey, setAdminKey] = useState('')
-  const [filterType, setFilterType] = useState('')
+  const [filterType, setFilterType] = useState(initialType)
   const [filterStatus, setFilterStatus] = useState('')
   const [filterSearch, setFilterSearch] = useState('')
   const [feedback, setFeedback] = useState(null)
-  const [confirmDelete, setConfirmDelete] = useState(null)
+
+  useEffect(() => {
+    setFilterType(initialType)
+  }, [initialType])
 
   function showFeedback(msg, isError = false) {
     setFeedback({ msg, isError })
@@ -351,6 +359,14 @@ export default function AssetsAdmin() {
     }
     return true
   })
+
+  function handleFilterTypeChange(nextType) {
+    setFilterType(nextType)
+    const next = new URLSearchParams(searchParams)
+    if (nextType) next.set('type', nextType)
+    else next.delete('type')
+    setSearchParams(next, { replace: true })
+  }
 
   return (
     <div className="flex flex-col gap-4 p-4 overflow-y-auto h-full">
@@ -425,7 +441,7 @@ export default function AssetsAdmin() {
         />
         <select
           value={filterType}
-          onChange={(e) => setFilterType(e.target.value)}
+          onChange={(e) => handleFilterTypeChange(e.target.value)}
           className="bg-surface border border-border rounded px-2 py-1.5 text-sm text-primary"
         >
           <option value="">Todos os tipos</option>

--- a/src/dashboard/frontend/src/pages/AssetsAdmin.test.jsx
+++ b/src/dashboard/frontend/src/pages/AssetsAdmin.test.jsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { vi } from "vitest";
 import AssetsAdmin from "./AssetsAdmin";
 
@@ -24,6 +25,14 @@ function setupMockAssets(overrides = {}) {
   });
 }
 
+function renderWithRouter(initialEntries = ["/admin/assets"]) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <AssetsAdmin />
+    </MemoryRouter>,
+  );
+}
+
 describe("AssetsAdmin", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -31,20 +40,20 @@ describe("AssetsAdmin", () => {
   });
 
   it("renders the page title and empty state message", () => {
-    render(<AssetsAdmin />);
+    renderWithRouter();
     expect(screen.getByText("Cadastro de Ativos")).toBeInTheDocument();
     expect(screen.getByText(/Nenhum ativo cadastrado/)).toBeInTheDocument();
   });
 
   it("shows loading state", () => {
     setupMockAssets({ assetsLoading: true });
-    render(<AssetsAdmin />);
+    renderWithRouter();
     expect(screen.getByText("Carregando ativos...")).toBeInTheDocument();
   });
 
   it("shows error state", () => {
     setupMockAssets({ assetsError: "Network error" });
-    render(<AssetsAdmin />);
+    renderWithRouter();
     expect(screen.getByText(/Erro: Network error/)).toBeInTheDocument();
   });
 
@@ -71,14 +80,14 @@ describe("AssetsAdmin", () => {
         },
       ],
     });
-    render(<AssetsAdmin />);
+    renderWithRouter();
     expect(screen.getByText("Sensor Porta")).toBeInTheDocument();
     expect(screen.getByText("Camera Entrada")).toBeInTheDocument();
     expect(screen.getByText(/binary_sensor.porta/)).toBeInTheDocument();
   });
 
   it("shows the form when clicking Novo Ativo", () => {
-    render(<AssetsAdmin />);
+    renderWithRouter();
     const btn = screen.getByText("+ Novo Ativo");
     fireEvent.click(btn);
     expect(screen.getByText("Novo Ativo")).toBeInTheDocument();
@@ -86,7 +95,7 @@ describe("AssetsAdmin", () => {
   });
 
   it("closes the form when clicking Cancelar", () => {
-    render(<AssetsAdmin />);
+    renderWithRouter();
     fireEvent.click(screen.getByText("+ Novo Ativo"));
     expect(screen.getByPlaceholderText(/ex: Sensor Porta Entrada/)).toBeInTheDocument();
     fireEvent.click(screen.getByText("Cancelar"));
@@ -94,21 +103,21 @@ describe("AssetsAdmin", () => {
   });
 
   it("shows admin key input field", () => {
-    render(<AssetsAdmin />);
+    renderWithRouter();
     expect(
       screen.getByPlaceholderText(/Necessária para criar, editar ou desativar ativos/),
     ).toBeInTheDocument();
   });
 
   it("shows filter controls", () => {
-    render(<AssetsAdmin />);
+    renderWithRouter();
     expect(screen.getByPlaceholderText(/Buscar por nome ou entity_id/)).toBeInTheDocument();
     expect(screen.getByText("Todos os tipos")).toBeInTheDocument();
     expect(screen.getByText("Todos os status")).toBeInTheDocument();
   });
 
   it("calls refetch when clicking Atualizar", () => {
-    render(<AssetsAdmin />);
+    renderWithRouter();
     const btn = screen.getByText("↻ Atualizar");
     fireEvent.click(btn);
     expect(mockRefetch).toHaveBeenCalledOnce();
@@ -128,7 +137,7 @@ describe("AssetsAdmin", () => {
         },
       ],
     });
-    render(<AssetsAdmin />);
+    renderWithRouter();
     expect(screen.getByText("Sensor Inativo")).toBeInTheDocument();
     // Ativo inativo deve ter botão Restaurar, não Desativar
     expect(screen.getByText("Restaurar")).toBeInTheDocument();
@@ -136,7 +145,7 @@ describe("AssetsAdmin", () => {
   });
 
   it("shows form validation error for missing admin key", async () => {
-    render(<AssetsAdmin />);
+    renderWithRouter();
     fireEvent.click(screen.getByText("+ Novo Ativo"));
 
     const nameInput = screen.getByPlaceholderText(/ex: Sensor Porta Entrada/);
@@ -177,11 +186,40 @@ describe("AssetsAdmin", () => {
         },
       ],
     });
-    render(<AssetsAdmin />);
+    renderWithRouter();
 
     const searchInput = screen.getByPlaceholderText(/Buscar por nome ou entity_id/);
     fireEvent.change(searchInput, { target: { value: "Camera" } });
 
+    expect(screen.getByText("Camera Entrada")).toBeInTheDocument();
+    expect(screen.queryByText("Sensor Porta")).not.toBeInTheDocument();
+  });
+
+  it("applies filterType from query param", () => {
+    setupMockAssets({
+      assets: [
+        {
+          id: "uuid-1",
+          name: "Sensor Porta",
+          entity_id: "binary_sensor.porta",
+          asset_type: "sensor",
+          status: "active",
+          is_active: true,
+          location: null,
+        },
+        {
+          id: "uuid-2",
+          name: "Camera Entrada",
+          entity_id: "camera.entrada",
+          asset_type: "camera",
+          status: "active",
+          is_active: true,
+          location: null,
+        },
+      ],
+    });
+
+    renderWithRouter(["/admin/assets?type=camera"]);
     expect(screen.getByText("Camera Entrada")).toBeInTheDocument();
     expect(screen.queryByText("Sensor Porta")).not.toBeInTheDocument();
   });

--- a/src/dashboard/frontend/src/pages/Dashboard.jsx
+++ b/src/dashboard/frontend/src/pages/Dashboard.jsx
@@ -3,6 +3,7 @@ import AlarmStatus from '../components/AlarmStatus'
 import CameraGrid from '../components/CameraGrid'
 import DroneStatus from '../components/DroneStatus'
 import OperationalMap from '../components/OperationalMap'
+import QuickActionsMenu from '../components/QuickActionsMenu'
 import SensorGrid from '../components/SensorGrid'
 import ServiceStatus from '../components/ServiceStatus'
 
@@ -11,6 +12,7 @@ export default function Dashboard() {
     <div className="flex-1 grid grid-cols-[280px_1fr_280px] gap-3 p-3 overflow-hidden h-full">
       {/* Coluna Esquerda */}
       <div className="flex flex-col gap-3 overflow-y-auto">
+        <QuickActionsMenu />
         <AlarmStatus />
         <SensorGrid />
         <AlertFeed />

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -13,7 +13,7 @@ O projeto combina automação, vídeo inteligente, sensores e drones para segura
 | **Zigbee2MQTT** | Bridge Zigbee → MQTT para sensores sem fio |
 | **Mosquitto** | Broker MQTT — barramento de eventos |
 | **PostgreSQL 16** | Banco de dados central (schemas isolados por serviço) |
-| **Dashboard** | Interface operacional React (modo completo + kiosk) |
+| **Dashboard** | Interface operacional React (modo completo + kiosk) com menu de atalhos para admin/cadastros |
 | **Docker / K3s** | Execução em dev (Compose) e prod (K3s) |
 
 ## Comece por aqui

--- a/wiki/Operacao-e-Manutencao.md
+++ b/wiki/Operacao-e-Manutencao.md
@@ -8,6 +8,16 @@ Acesse `http://localhost:3000` (ou `dashboard.home.local` em produção):
 
 - **Modo completo (`/`)**: visão completa com alarme, sensores, mapa, câmeras, drones e status dos serviços
 - **Modo kiosk (`/simplified`)**: tela de TV/monitor dedicado — barra de alarme, mapa e grid de câmeras
+- **Admin de ativos (`/admin/assets`)**: CRUD de sensores, câmeras, UGV e UAV
+
+No modo completo (`/`), o card **Menu Operacional** traz atalhos diretos para:
+
+- Administração de ativos
+- Cadastro de sensores (`/admin/assets?type=sensor`)
+- Cadastro de câmeras (`/admin/assets?type=camera`)
+- Cadastro de drones UGV (`/admin/assets?type=ugv`)
+- Cadastro de drones UAV (`/admin/assets?type=uav`)
+- Modo kiosk (`/simplified`)
 
 O dashboard atualiza em tempo real via WebSocket (fan-out do Home Assistant).
 


### PR DESCRIPTION
## Resumo
- adiciona card "Menu Operacional" na home (/)
- inclui atalhos para Admin de Ativos e cadastros filtrados de sensores, câmeras, UGV e UAV
- sincroniza filtro de tipo no AssetsAdmin via query param (?type=)
- atualiza testes de rotas e da página de ativos
- atualiza README e wiki com nova navegação operacional

## Validação
- npm run lint (frontend)
- npm run test (frontend)

Closes #367
