### PR TITLE
feat(dashboard): menu dropdown no header ao lado do botão kiosk

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Para testar o sistema em seu computador ou servidor de desenvolvimento:
 
 ### Navegação do Dashboard
 
-- `/` — dashboard completo com **Menu Operacional** (atalhos para admin e cadastros).
+- `/` — dashboard completo com **Menu Operacional** no canto superior direito (ícone ao lado do botão Kiosk).
 - `/admin/assets` — administração de ativos (CRUD de sensores, câmeras, UGV e UAV).
 - `/admin/assets?type=sensor|camera|ugv|uav` — cadastro com filtro inicial por tipo.
 - `/simplified` — modo kiosk/simplificado para monitor dedicado.

--- a/src/dashboard/frontend/src/App.test.jsx
+++ b/src/dashboard/frontend/src/App.test.jsx
@@ -96,7 +96,11 @@ describe("App routing and dashboard", () => {
     expect(await screen.findByText(/HOME SECURITY/i)).toBeInTheDocument();
     expect(screen.getByText("Mapa Operacional")).toBeInTheDocument();
     expect(screen.getByText("Drones")).toBeInTheDocument();
-    expect(screen.getByText("Menu Operacional")).toBeInTheDocument();
+    const menuButton = screen.getByRole("button", { name: /Abrir menu operacional/i });
+    expect(menuButton).toBeInTheDocument();
+    fireEvent.click(menuButton);
+    expect(screen.getByRole("navigation", { name: /Menu Operacional/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /^Home$/i })).toHaveAttribute("href", "/");
     expect(screen.getByRole("link", { name: /Admin de Ativos/i })).toHaveAttribute("href", "/admin/assets");
     expect(screen.getByRole("link", { name: /Cadastro de Sensores/i })).toHaveAttribute("href", "/admin/assets?type=sensor");
     expect(screen.getByRole("link", { name: /Cadastro de Câmeras/i })).toHaveAttribute("href", "/admin/assets?type=camera");

--- a/src/dashboard/frontend/src/components/Header.jsx
+++ b/src/dashboard/frontend/src/components/Header.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
+import QuickActionsMenu from './QuickActionsMenu'
 import useStore from '../store/useStore'
 
 export default function Header() {
@@ -42,6 +43,7 @@ export default function Header() {
         <span className="font-mono text-gray-300">
           {time.toLocaleTimeString('pt-BR')}
         </span>
+        <QuickActionsMenu />
         <Link
           to={isSimplified ? '/' : '/simplified'}
           className="px-2 py-1 rounded bg-border hover:bg-accent/20 text-xs transition-colors"

--- a/src/dashboard/frontend/src/components/QuickActionsMenu.jsx
+++ b/src/dashboard/frontend/src/components/QuickActionsMenu.jsx
@@ -1,30 +1,65 @@
+import { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 
 const LINKS = [
-  { to: '/admin/assets', label: 'Admin de Ativos', description: 'Gestão completa de sensores, câmeras e drones.' },
-  { to: '/admin/assets?type=sensor', label: 'Cadastro de Sensores', description: 'Abrir cadastro já filtrado para sensores.' },
-  { to: '/admin/assets?type=camera', label: 'Cadastro de Câmeras', description: 'Abrir cadastro já filtrado para câmeras.' },
-  { to: '/admin/assets?type=ugv', label: 'Cadastro UGV', description: 'Abrir cadastro já filtrado para drones terrestres.' },
-  { to: '/admin/assets?type=uav', label: 'Cadastro UAV', description: 'Abrir cadastro já filtrado para drones aéreos.' },
-  { to: '/simplified', label: 'Modo Kiosk', description: 'Tela simplificada para monitor dedicado.' },
+  { to: '/', label: 'Home' },
+  { to: '/admin/assets', label: 'Admin de Ativos' },
+  { to: '/admin/assets?type=sensor', label: 'Cadastro de Sensores' },
+  { to: '/admin/assets?type=camera', label: 'Cadastro de Câmeras' },
+  { to: '/admin/assets?type=ugv', label: 'Cadastro UGV' },
+  { to: '/admin/assets?type=uav', label: 'Cadastro UAV' },
+  { to: '/simplified', label: 'Modo Kiosk' },
 ]
 
 export default function QuickActionsMenu() {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef(null)
+
+  useEffect(() => {
+    function onDocumentClick(event) {
+      if (!containerRef.current) return
+      if (!containerRef.current.contains(event.target)) setOpen(false)
+    }
+    function onEscape(event) {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDocumentClick)
+    document.addEventListener('keydown', onEscape)
+    return () => {
+      document.removeEventListener('mousedown', onDocumentClick)
+      document.removeEventListener('keydown', onEscape)
+    }
+  }, [])
+
   return (
-    <div className="card flex flex-col gap-2">
-      <h2 className="text-xs font-semibold uppercase tracking-wider text-muted">Menu Operacional</h2>
-      <div className="grid gap-2">
-        {LINKS.map((link) => (
-          <Link
-            key={link.to}
-            to={link.to}
-            className="block rounded border border-border bg-surface px-2 py-2 hover:border-accent/50 hover:bg-accent/5 transition-colors"
-          >
-            <p className="text-sm font-medium text-primary">{link.label}</p>
-            <p className="text-xs text-muted">{link.description}</p>
-          </Link>
-        ))}
-      </div>
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        aria-label="Abrir menu operacional"
+        aria-expanded={open ? 'true' : 'false'}
+        onClick={() => setOpen((prev) => !prev)}
+        className="h-11 w-11 rounded bg-[#1f2125] border border-border text-[#56c6b3] hover:bg-[#2a2d31] transition-colors flex items-center justify-center"
+      >
+        <span className="text-xl leading-none">☰</span>
+      </button>
+
+      {open && (
+        <nav
+          aria-label="Menu Operacional"
+          className="absolute right-0 top-14 z-50 min-w-[260px] rounded bg-[#24262b] border border-[#30323a] py-2 shadow-xl"
+        >
+          {LINKS.map((link) => (
+            <Link
+              key={link.to}
+              to={link.to}
+              onClick={() => setOpen(false)}
+              className="block px-4 py-2 text-lg text-[#7a7d84] hover:text-[#56c6b3] hover:bg-[#2b2d33] transition-colors"
+            >
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+      )}
     </div>
   )
 }

--- a/src/dashboard/frontend/src/pages/Dashboard.jsx
+++ b/src/dashboard/frontend/src/pages/Dashboard.jsx
@@ -3,7 +3,6 @@ import AlarmStatus from '../components/AlarmStatus'
 import CameraGrid from '../components/CameraGrid'
 import DroneStatus from '../components/DroneStatus'
 import OperationalMap from '../components/OperationalMap'
-import QuickActionsMenu from '../components/QuickActionsMenu'
 import SensorGrid from '../components/SensorGrid'
 import ServiceStatus from '../components/ServiceStatus'
 
@@ -12,7 +11,6 @@ export default function Dashboard() {
     <div className="flex-1 grid grid-cols-[280px_1fr_280px] gap-3 p-3 overflow-hidden h-full">
       {/* Coluna Esquerda */}
       <div className="flex flex-col gap-3 overflow-y-auto">
-        <QuickActionsMenu />
         <AlarmStatus />
         <SensorGrid />
         <AlertFeed />

--- a/wiki/Operacao-e-Manutencao.md
+++ b/wiki/Operacao-e-Manutencao.md
@@ -10,7 +10,7 @@ Acesse `http://localhost:3000` (ou `dashboard.home.local` em produção):
 - **Modo kiosk (`/simplified`)**: tela de TV/monitor dedicado — barra de alarme, mapa e grid de câmeras
 - **Admin de ativos (`/admin/assets`)**: CRUD de sensores, câmeras, UGV e UAV
 
-No modo completo (`/`), o card **Menu Operacional** traz atalhos diretos para:
+No modo completo (`/`), o **Menu Operacional** (ícone no topo direito, ao lado do botão Kiosk) traz atalhos diretos para:
 
 - Administração de ativos
 - Cadastro de sensores (`/admin/assets?type=sensor`)


### PR DESCRIPTION
## Resumo
- transforma o Menu Operacional para o padrão visual do mock (ícone hambúrguer + dropdown escuro)
- move o menu para o canto superior direito do header, ao lado do botão Kiosk
- remove o card de menu da coluna esquerda do dashboard
- mantém atalhos para Home, Admin de Ativos, cadastros por tipo e Kiosk
- atualiza teste de rota principal para validar o novo fluxo (abrir menu e checar links)

## Validação
- npm run lint
- npm run test

Closes #369
