### PR TITLE
fix(sonar): fechar todas as issues abertas sincronizadas do SonarQube

### DIFF
--- a/src/dashboard/backend/app/routers/assets.py
+++ b/src/dashboard/backend/app/routers/assets.py
@@ -15,6 +15,7 @@ from app.db.session import get_db
 from app.security import require_admin_key
 
 router = APIRouter(prefix="/api/assets", tags=["assets"])
+ASSET_NOT_FOUND_DETAIL = "Asset not found."
 
 # ---------------------------------------------------------------------------
 # Schemas Pydantic
@@ -173,7 +174,7 @@ async def get_asset(asset_id: uuid.UUID, db: AsyncSession = Depends(get_db)) -> 
     result = await db.execute(select(Asset).where(Asset.id == asset_id))
     asset = result.scalar_one_or_none()
     if not asset:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Asset not found.")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ASSET_NOT_FOUND_DETAIL)
     return _asset_to_dict(asset)
 
 
@@ -251,7 +252,7 @@ async def update_asset(
     result = await db.execute(select(Asset).where(Asset.id == asset_id))
     asset = result.scalar_one_or_none()
     if not asset:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Asset not found.")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ASSET_NOT_FOUND_DETAIL)
 
     before = _asset_to_dict(asset)
     actor = _get_actor(request)
@@ -300,7 +301,7 @@ async def delete_asset(
     result = await db.execute(select(Asset).where(Asset.id == asset_id))
     asset = result.scalar_one_or_none()
     if not asset:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Asset not found.")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ASSET_NOT_FOUND_DETAIL)
 
     before = _asset_to_dict(asset)
     actor = _get_actor(request)
@@ -338,7 +339,7 @@ async def restore_asset(
     result = await db.execute(select(Asset).where(Asset.id == asset_id))
     asset = result.scalar_one_or_none()
     if not asset:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Asset not found.")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ASSET_NOT_FOUND_DETAIL)
 
     before = _asset_to_dict(asset)
     actor = _get_actor(request)

--- a/src/dashboard/backend/migrations/versions/20260223_0003_assets_catalog_and_audit.py
+++ b/src/dashboard/backend/migrations/versions/20260223_0003_assets_catalog_and_audit.py
@@ -15,6 +15,7 @@ revision: str = "20260223_0003"
 down_revision: Union[str, None] = "20260219_0002"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
+NOW_SQL = "now()"
 
 
 def upgrade() -> None:
@@ -34,13 +35,13 @@ def upgrade() -> None:
             "created_at",
             sa.DateTime(timezone=True),
             nullable=False,
-            server_default=sa.text("now()"),
+            server_default=sa.text(NOW_SQL),
         ),
         sa.Column(
             "updated_at",
             sa.DateTime(timezone=True),
             nullable=False,
-            server_default=sa.text("now()"),
+            server_default=sa.text(NOW_SQL),
         ),
         sa.Column("created_by", sa.String(length=100), nullable=True),
         sa.Column("updated_by", sa.String(length=100), nullable=True),
@@ -89,7 +90,7 @@ def upgrade() -> None:
             "created_at",
             sa.DateTime(timezone=True),
             nullable=False,
-            server_default=sa.text("now()"),
+            server_default=sa.text(NOW_SQL),
         ),
         sa.ForeignKeyConstraint(
             ["asset_id"],
@@ -121,7 +122,7 @@ def upgrade() -> None:
             "created_at",
             sa.DateTime(timezone=True),
             nullable=False,
-            server_default=sa.text("now()"),
+            server_default=sa.text(NOW_SQL),
         ),
         sa.CheckConstraint(
             "action IN ('create', 'update', 'delete', 'restore')",

--- a/src/dashboard/frontend/src/pages/AssetsAdmin.jsx
+++ b/src/dashboard/frontend/src/pages/AssetsAdmin.jsx
@@ -47,6 +47,9 @@ function AssetForm({ initial, onSave, onCancel, adminKey }) {
   const [saving, setSaving] = useState(false)
 
   const isEdit = Boolean(initial?.id)
+  let submitLabel = 'Cadastrar'
+  if (saving) submitLabel = 'Salvando...'
+  else if (isEdit) submitLabel = 'Atualizar'
 
   async function handleSubmit(e) {
     e.preventDefault()
@@ -212,7 +215,7 @@ function AssetForm({ initial, onSave, onCancel, adminKey }) {
           disabled={saving}
           className="px-4 py-1.5 text-sm bg-accent text-white rounded hover:bg-accent/80 transition-colors disabled:opacity-50"
         >
-          {saving ? 'Salvando...' : isEdit ? 'Atualizar' : 'Cadastrar'}
+          {submitLabel}
         </button>
       </div>
     </form>
@@ -368,6 +371,54 @@ export default function AssetsAdmin() {
     setSearchParams(next, { replace: true })
   }
 
+  function renderTableContent() {
+    if (assetsLoading) {
+      return <p className="text-muted text-sm text-center py-6">Carregando ativos...</p>
+    }
+
+    if (assetsError) {
+      return <p className="text-critical text-sm text-center py-6">Erro: {assetsError}</p>
+    }
+
+    if (filtered.length === 0) {
+      const emptyMessage = assets.length === 0
+        ? 'Nenhum ativo cadastrado. Clique em "+ Novo Ativo" para começar.'
+        : 'Nenhum ativo encontrado com os filtros aplicados.'
+      return <p className="text-muted text-sm text-center py-6">{emptyMessage}</p>
+    }
+
+    return (
+      <div className="overflow-x-auto">
+        <table className="w-full text-left">
+          <thead>
+            <tr className="border-b border-border">
+              <th className="px-3 py-2 text-xs font-semibold text-muted uppercase">Nome / Entity ID</th>
+              <th className="px-3 py-2 text-xs font-semibold text-muted uppercase">Tipo</th>
+              <th className="px-3 py-2 text-xs font-semibold text-muted uppercase">Status</th>
+              <th className="px-3 py-2 text-xs font-semibold text-muted uppercase">Local</th>
+              <th className="px-3 py-2 text-xs font-semibold text-muted uppercase">Visível</th>
+              <th className="px-3 py-2 text-xs font-semibold text-muted uppercase">Ações</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((asset) => (
+              <AssetRow
+                key={asset.id}
+                asset={asset}
+                onEdit={(a) => { setEditTarget(a); setShowForm(true) }}
+                onDelete={handleDelete}
+                onRestore={handleRestore}
+              />
+            ))}
+          </tbody>
+        </table>
+        <p className="text-xs text-muted px-3 py-2 border-t border-border">
+          {filtered.length} de {assets.length} ativos
+        </p>
+      </div>
+    )
+  }
+
   return (
     <div className="flex flex-col gap-4 p-4 overflow-y-auto h-full">
       {/* Cabeçalho */}
@@ -469,46 +520,7 @@ export default function AssetsAdmin() {
 
       {/* Tabela */}
       <div className="card overflow-hidden">
-        {assetsLoading ? (
-          <p className="text-muted text-sm text-center py-6">Carregando ativos...</p>
-        ) : assetsError ? (
-          <p className="text-critical text-sm text-center py-6">Erro: {assetsError}</p>
-        ) : filtered.length === 0 ? (
-          <p className="text-muted text-sm text-center py-6">
-            {assets.length === 0
-              ? 'Nenhum ativo cadastrado. Clique em "+ Novo Ativo" para começar.'
-              : 'Nenhum ativo encontrado com os filtros aplicados.'}
-          </p>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-left">
-              <thead>
-                <tr className="border-b border-border">
-                  <th className="px-3 py-2 text-xs font-semibold text-muted uppercase">Nome / Entity ID</th>
-                  <th className="px-3 py-2 text-xs font-semibold text-muted uppercase">Tipo</th>
-                  <th className="px-3 py-2 text-xs font-semibold text-muted uppercase">Status</th>
-                  <th className="px-3 py-2 text-xs font-semibold text-muted uppercase">Local</th>
-                  <th className="px-3 py-2 text-xs font-semibold text-muted uppercase">Visível</th>
-                  <th className="px-3 py-2 text-xs font-semibold text-muted uppercase">Ações</th>
-                </tr>
-              </thead>
-              <tbody>
-                {filtered.map((asset) => (
-                  <AssetRow
-                    key={asset.id}
-                    asset={asset}
-                    onEdit={(a) => { setEditTarget(a); setShowForm(true) }}
-                    onDelete={handleDelete}
-                    onRestore={handleRestore}
-                  />
-                ))}
-              </tbody>
-            </table>
-            <p className="text-xs text-muted px-3 py-2 border-t border-border">
-              {filtered.length} de {assets.length} ativos
-            </p>
-          </div>
-        )}
+        {renderTableContent()}
       </div>
     </div>
   )

--- a/tests/backend/test_assets_api.py
+++ b/tests/backend/test_assets_api.py
@@ -17,6 +17,7 @@ from app.security import require_api_key
 OPERATOR_KEY = "test-api-key"
 ADMIN_KEY = "test-admin-key"
 TEST_BASE_URL = "http://testserver"
+ASSETS_ENDPOINT = "/api/assets"
 
 
 # ---------------------------------------------------------------------------
@@ -89,13 +90,16 @@ class _FakeSession:
         self.added.append(obj)
 
     async def flush(self):
-        pass
+        # No-op intencional para o test double de sessão.
+        return None
 
     async def commit(self):
-        pass
+        # No-op intencional para o test double de sessão.
+        return None
 
     async def refresh(self, obj):
-        pass
+        # No-op intencional para o test double de sessão.
+        return None
 
 
 def _build_test_app(db_rows=None, conflict=False):
@@ -122,7 +126,7 @@ async def test_list_assets_requires_operator_key():
     app = _build_test_app()
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
-        resp = await client.get("/api/assets")
+        resp = await client.get(ASSETS_ENDPOINT)
     assert resp.status_code == 403
 
 
@@ -132,7 +136,7 @@ async def test_list_assets_with_operator_key():
     app = _build_test_app(db_rows=[_make_asset()])
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
-        resp = await client.get("/api/assets", headers={"X-API-Key": OPERATOR_KEY})
+        resp = await client.get(ASSETS_ENDPOINT, headers={"X-API-Key": OPERATOR_KEY})
     assert resp.status_code == 200
     data = resp.json()
     assert "items" in data
@@ -148,7 +152,7 @@ async def test_create_asset_requires_admin_key():
     async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
         # Sem admin key — deve falhar (apenas operator key)
         resp = await client.post(
-            "/api/assets",
+            ASSETS_ENDPOINT,
             headers={"X-API-Key": OPERATOR_KEY},
             json={
                 "asset_type": "sensor",
@@ -166,7 +170,7 @@ async def test_create_asset_with_wrong_admin_key():
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
         resp = await client.post(
-            "/api/assets",
+            ASSETS_ENDPOINT,
             headers={"X-API-Key": OPERATOR_KEY, "X-Admin-Key": "wrong-key"},
             json={
                 "asset_type": "sensor",
@@ -185,7 +189,7 @@ async def test_delete_asset_requires_admin_key():
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
         resp = await client.delete(
-            f"/api/assets/{asset_id}",
+            f"{ASSETS_ENDPOINT}/{asset_id}",
             headers={"X-API-Key": OPERATOR_KEY},
         )
     assert resp.status_code in (403, 503)
@@ -202,7 +206,7 @@ async def test_list_assets_empty():
     app = _build_test_app(db_rows=[])
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
-        resp = await client.get("/api/assets", headers={"X-API-Key": OPERATOR_KEY})
+        resp = await client.get(ASSETS_ENDPOINT, headers={"X-API-Key": OPERATOR_KEY})
     assert resp.status_code == 200
     assert resp.json()["items"] == []
 
@@ -214,7 +218,7 @@ async def test_list_assets_pagination_params():
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
         resp = await client.get(
-            "/api/assets?limit=2&offset=1",
+            f"{ASSETS_ENDPOINT}?limit=2&offset=1",
             headers={"X-API-Key": OPERATOR_KEY},
         )
     assert resp.status_code == 200
@@ -230,7 +234,7 @@ async def test_get_asset_not_found():
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
         resp = await client.get(
-            f"/api/assets/{uuid.uuid4()}",
+            f"{ASSETS_ENDPOINT}/{uuid.uuid4()}",
             headers={"X-API-Key": OPERATOR_KEY},
         )
     assert resp.status_code == 404
@@ -244,7 +248,7 @@ async def test_get_asset_found():
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
         resp = await client.get(
-            f"/api/assets/{asset.id}",
+            f"{ASSETS_ENDPOINT}/{asset.id}",
             headers={"X-API-Key": OPERATOR_KEY},
         )
     assert resp.status_code == 200
@@ -260,7 +264,7 @@ async def test_create_asset_invalid_payload():
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
         resp = await client.post(
-            "/api/assets",
+            ASSETS_ENDPOINT,
             headers={"X-API-Key": OPERATOR_KEY, "X-Admin-Key": ADMIN_KEY},
             json={"asset_type": "invalid_type", "name": "X", "entity_id": "test.x"},
         )
@@ -274,7 +278,7 @@ async def test_create_asset_entity_id_with_space():
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
         resp = await client.post(
-            "/api/assets",
+            ASSETS_ENDPOINT,
             headers={"X-API-Key": OPERATOR_KEY, "X-Admin-Key": ADMIN_KEY},
             json={"asset_type": "sensor", "name": "X", "entity_id": "binary sensor.teste"},
         )
@@ -288,7 +292,7 @@ async def test_create_asset_invalid_config_json():
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
         resp = await client.post(
-            "/api/assets",
+            ASSETS_ENDPOINT,
             headers={"X-API-Key": OPERATOR_KEY, "X-Admin-Key": ADMIN_KEY},
             json={
                 "asset_type": "sensor",
@@ -313,7 +317,7 @@ async def test_asset_response_has_no_sensitive_fields():
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
         resp = await client.get(
-            f"/api/assets/{asset.id}",
+            f"{ASSETS_ENDPOINT}/{asset.id}",
             headers={"X-API-Key": OPERATOR_KEY},
         )
     assert resp.status_code == 200

--- a/tests/backend/test_assets_e2e_smoke_contract.py
+++ b/tests/backend/test_assets_e2e_smoke_contract.py
@@ -20,6 +20,7 @@ from app.security import require_api_key
 OPERATOR_KEY = "test-api-key"
 ADMIN_KEY = "test-admin-key"
 TEST_BASE_URL = "http://testserver"
+ASSETS_ENDPOINT = "/api/assets"
 
 
 class _FullSmokeSession:
@@ -74,7 +75,8 @@ class _FullSmokeSession:
         self.committed.append(True)
 
     async def refresh(self, obj):
-        pass
+        # No-op intencional para o test double de sessão.
+        return None
 
 
 def _build_smoke_app():
@@ -103,7 +105,7 @@ async def test_smoke_create_asset_generates_audit_event():
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
         resp = await client.post(
-            "/api/assets",
+            ASSETS_ENDPOINT,
             headers={"X-API-Key": OPERATOR_KEY, "X-Admin-Key": ADMIN_KEY},
             json={
                 "asset_type": "sensor",
@@ -249,7 +251,7 @@ async def test_smoke_rbac_create_blocked_without_admin_key():
     async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
         # Sem X-Admin-Key
         resp = await client.post(
-            "/api/assets",
+            ASSETS_ENDPOINT,
             headers={"X-API-Key": OPERATOR_KEY},  # operator key, sem admin key
             json={
                 "asset_type": "sensor",
@@ -270,7 +272,7 @@ async def test_smoke_list_assets_no_auth_returns_403():
     app, session = _build_smoke_app()
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
-        resp = await client.get("/api/assets")
+        resp = await client.get(ASSETS_ENDPOINT)
     assert resp.status_code == 403
 
 
@@ -304,9 +306,6 @@ async def test_smoke_no_regression_alerts_endpoint():
     mock_alert.new_state = "on"
     mock_alert.severity = "warning"
     mock_alert.message = None
-
-    # Sobrescrever execute temporariamente para retornar o alerta
-    original_execute = session.execute
 
     async def _exec_alerts(stmt):
         result = MagicMock()

--- a/tests/backend/test_rbac_assets_contract.py
+++ b/tests/backend/test_rbac_assets_contract.py
@@ -9,9 +9,6 @@ class TestRBACMatrix:
     def test_rbac_matrix_viewer_only_read(self):
         """viewer: somente leitura — endpoints GET são permitidos, POST/PUT/DELETE exigem admin."""
         # Esta é uma validação de design: leitura pública (com operator key), escrita requer admin
-        readonly_methods = ["GET"]
-        write_methods = ["POST", "PUT", "DELETE"]
-
         # Valida que a separação está clara na implementação
         from app.routers.assets import router
 
@@ -83,7 +80,6 @@ class TestRBACAdminKeyConfig:
         # Patch settings para admin key vazia
         from app import config as cfg_module
 
-        original_key = cfg_module.settings.dashboard_admin_key
         monkeypatch.setattr(cfg_module.settings, "dashboard_admin_key", "")
 
         from app.security import require_admin_key


### PR DESCRIPTION
## Resumo
Este PR resolve todas as issues abertas do SonarQube no repositório (backend, frontend e testes), incluindo:
- extração de literais duplicadas para constantes
- remoção de variáveis locais não utilizadas
- remoção/refatoração de ternários aninhados no frontend
- implementação explícita de no-op em test doubles

## Validação executada
- `npm run lint` (frontend)
- `npm run test` (frontend)
- `PYTHONPATH=src/dashboard/backend .venv/bin/pytest -q tests/backend/test_assets_api.py tests/backend/test_rbac_assets_contract.py tests/backend/test_assets_e2e_smoke_contract.py`

## Fechamentos
Closes #343
Closes #344
Closes #345
Closes #346
Closes #347
Closes #348
Closes #349
Closes #350
Closes #351
Closes #353
Closes #360
Closes #361
Closes #363
Closes #364
Closes #365
