### PR TITLE
ci(sonar): usar runtimes locais no runner self-hosted

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -50,23 +50,18 @@ jobs:
           distribution: temurin
           java-version: "17"
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
+      - name: Check local runtimes
+        run: |
+          python3 --version
+          npm --version
 
       - name: Generate backend coverage report (>=90%)
         run: |
           set -euo pipefail
-          python -m pip install --upgrade pip
-          python -m pip install -r src/dashboard/backend/requirements.txt pytest pytest-cov
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r src/dashboard/backend/requirements.txt pytest pytest-cov
           mkdir -p coverage
-          PYTHONPATH=src/dashboard/backend pytest -q \
+          PYTHONPATH=src/dashboard/backend python3 -m pytest -q \
             tests/backend/test_assets_api.py \
             tests/backend/test_assets_e2e_smoke_contract.py \
             tests/backend/test_assets_router_coverage.py \


### PR DESCRIPTION
## Resumo
- remove setup-python/setup-node do workflow Sonar (quebravam no runner self-hosted)
- usa python3 e npm já instalados no host
- mantém geração de coverage backend/frontend e scan Sonar

## Motivação
Execuções em main falharam em actions/setup-python por indisponibilidade/permissão no host Debian.
