### PR TITLE
test: elevar cobertura do dashboard para 100% de linhas

### DIFF
--- a/src/dashboard/frontend/src/components/AlertFeed.test.jsx
+++ b/src/dashboard/frontend/src/components/AlertFeed.test.jsx
@@ -13,6 +13,7 @@ vi.mock("../store/useStore", () => ({
 
 describe("AlertFeed", () => {
   beforeEach(() => {
+    mockedStore.alerts = [];
     setAlertsIfEmpty.mockClear();
     global.fetch = vi.fn().mockResolvedValue({
       json: async () => [
@@ -37,5 +38,47 @@ describe("AlertFeed", () => {
   it("shows empty state", () => {
     render(<AlertFeed />);
     expect(screen.getByText("Nenhum alerta registrado.")).toBeInTheDocument();
+  });
+
+  it("renders alerts list with fallback label/style", () => {
+    mockedStore.alerts = [
+      {
+        id: 99,
+        timestamp: "2026-02-24T03:00:00.000Z",
+        entity_id: "device.unknown",
+        old_state: "off",
+        new_state: "on",
+        severity: "custom",
+      },
+    ];
+
+    render(<AlertFeed />);
+    expect(screen.getByText("device.unknown")).toBeInTheDocument();
+    expect(screen.getByText((text) => text.includes("off") && text.includes("on"))).toBeInTheDocument();
+  });
+
+  it("ignores initial payload when API does not return array", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: async () => ({ alerts: [] }),
+    });
+
+    render(<AlertFeed />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith("/api/alerts?limit=30"));
+    expect(setAlertsIfEmpty).not.toHaveBeenCalled();
+  });
+
+  it("uses timestamp as list key when id is missing", () => {
+    mockedStore.alerts = [
+      {
+        timestamp: "2026-02-24T04:00:00.000Z",
+        entity_id: "binary_sensor.porta_entrada",
+        old_state: "off",
+        new_state: "on",
+        severity: "critical",
+      },
+    ];
+
+    render(<AlertFeed />);
+    expect(screen.getByText("Porta Entrada")).toBeInTheDocument();
   });
 });

--- a/src/dashboard/frontend/src/components/CameraGrid.test.jsx
+++ b/src/dashboard/frontend/src/components/CameraGrid.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { vi } from "vitest";
 import CameraGrid from "./CameraGrid";
 import { useAssets } from "../hooks/useAssets";
@@ -17,6 +17,10 @@ vi.mock("../hooks/useAssets", () => ({
 }));
 
 describe("CameraGrid", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("renders static fallback cameras when no dynamic assets", () => {
     render(<CameraGrid />);
     // Com cameraAssets vazio, deve usar STATIC_CAMERAS (fallback)
@@ -42,5 +46,31 @@ describe("CameraGrid", () => {
     render(<CameraGrid />);
     expect(screen.getByText("Frente")).toBeInTheDocument();
     expect(screen.getByText("Quintal")).toBeInTheDocument();
+  });
+
+  it("shows offline fallback when snapshot fails and recovers on load", () => {
+    render(<CameraGrid />);
+    const firstImage = screen.getAllByRole("img")[0];
+
+    fireEvent.error(firstImage);
+    expect(screen.getByText("offline")).toBeInTheDocument();
+
+    fireEvent.load(firstImage);
+    expect(screen.queryByText("offline")).not.toBeInTheDocument();
+  });
+
+  it("refreshes snapshot URL on interval tick", () => {
+    vi.useFakeTimers();
+    render(<CameraGrid />);
+    const firstImage = screen.getAllByRole("img")[0];
+    const initialSrc = firstImage.getAttribute("src");
+
+    act(() => {
+      vi.advanceTimersByTime(2100);
+    });
+    const updatedSrc = screen.getAllByRole("img")[0].getAttribute("src");
+
+    expect(updatedSrc).not.toEqual(initialSrc);
+    expect(updatedSrc).toContain("/api/cameras/");
   });
 });

--- a/src/dashboard/frontend/src/components/DroneStatus.test.jsx
+++ b/src/dashboard/frontend/src/components/DroneStatus.test.jsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import DroneStatus from "./DroneStatus";
+
+const mockStore = { states: {} };
+
+vi.mock("../store/useStore", () => ({
+  default: () => mockStore,
+}));
+
+describe("DroneStatus", () => {
+  it("renders online/offline cards and battery levels", () => {
+    mockStore.states = {
+      "binary_sensor.ugv_online": { state: "off" },
+      "sensor.ugv_battery": { state: "10" },
+      "sensor.ugv_status": { state: "idle" },
+      "binary_sensor.uav_armed": { state: "true" },
+      "sensor.uav_battery": { state: "30" },
+      "sensor.uav_status": { state: "patrol" },
+    };
+
+    render(<DroneStatus />);
+    expect(screen.getByText("🤖 UGV")).toBeInTheDocument();
+    expect(screen.getByText("🚁 UAV")).toBeInTheDocument();
+    expect(screen.getByText("offline")).toBeInTheDocument();
+    expect(screen.getByText("online")).toBeInTheDocument();
+    expect(screen.getByText("10%")).toBeInTheDocument();
+    expect(screen.getByText("30%")).toBeInTheDocument();
+  });
+
+  it("handles non-numeric battery value as 0", () => {
+    mockStore.states = {
+      "binary_sensor.ugv_online": { state: "on" },
+      "sensor.ugv_battery": { state: "--" },
+      "sensor.ugv_status": { state: "idle" },
+      "binary_sensor.uav_armed": { state: "on" },
+      "sensor.uav_battery": { state: "80" },
+      "sensor.uav_status": { state: "ok" },
+    };
+
+    render(<DroneStatus />);
+    expect(screen.getByText("0%")).toBeInTheDocument();
+    expect(screen.getByText("80%")).toBeInTheDocument();
+  });
+
+  it("shows default placeholders when state entities are missing", () => {
+    mockStore.states = {};
+    render(<DroneStatus />);
+
+    expect(screen.getAllByText("desconhecido").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("--").length).toBeGreaterThan(0);
+  });
+});

--- a/src/dashboard/frontend/src/components/Header.test.jsx
+++ b/src/dashboard/frontend/src/components/Header.test.jsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import Header from "./Header";
+
+const mockStore = {
+  states: {},
+  wsStatus: "connected",
+};
+
+vi.mock("../store/useStore", () => ({
+  default: () => mockStore,
+}));
+
+vi.mock("./QuickActionsMenu", () => ({
+  default: () => <div data-testid="quick-actions-stub" />,
+}));
+
+describe("Header", () => {
+  it("renders triggered alarm and connected websocket label on dashboard route", () => {
+    mockStore.states = {
+      "alarm_control_panel.alarmo": { state: "triggered" },
+    };
+    mockStore.wsStatus = "connected";
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Header />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("🔴 ALARME DISPARADO")).toBeInTheDocument();
+    expect(screen.getByText(/ao vivo/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /⊟ Kiosk/i })).toHaveAttribute("href", "/simplified");
+    expect(screen.getByTestId("quick-actions-stub")).toBeInTheDocument();
+  });
+
+  it("renders fallback alarm label and full-mode link on simplified route", () => {
+    mockStore.states = {
+      "alarm_control_panel.alarmo": { state: "custom_state" },
+    };
+    mockStore.wsStatus = "disconnected";
+
+    render(
+      <MemoryRouter initialEntries={["/simplified"]}>
+        <Header />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("⚪ custom_state")).toBeInTheDocument();
+    expect(screen.getByText(/disconnected/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /⊞ Completo/i })).toHaveAttribute("href", "/");
+  });
+});

--- a/src/dashboard/frontend/src/components/QuickActionsMenu.test.jsx
+++ b/src/dashboard/frontend/src/components/QuickActionsMenu.test.jsx
@@ -30,4 +30,11 @@ describe("QuickActionsMenu", () => {
     fireEvent.mouseDown(document.body);
     expect(screen.queryByRole("navigation", { name: /Menu Operacional/i })).not.toBeInTheDocument();
   });
+
+  it("closes dropdown when clicking a menu link", () => {
+    renderMenu();
+    fireEvent.click(screen.getByRole("button", { name: /Abrir menu operacional/i }));
+    fireEvent.click(screen.getByRole("link", { name: "Admin de Ativos" }));
+    expect(screen.queryByRole("navigation", { name: /Menu Operacional/i })).not.toBeInTheDocument();
+  });
 });

--- a/src/dashboard/frontend/src/components/SensorGrid.test.jsx
+++ b/src/dashboard/frontend/src/components/SensorGrid.test.jsx
@@ -50,4 +50,33 @@ describe("SensorGrid", () => {
     expect(screen.getByText("Porta Frente")).toBeInTheDocument();
     expect(screen.getByText("aberto / detectado")).toBeInTheDocument();
   });
+
+  it("renders loading state when fetching and no sensors", () => {
+    mockUseAssets.mockReturnValueOnce({
+      sensorAssets: [],
+      assetsLoading: true,
+    });
+    render(<SensorGrid />);
+    expect(screen.getByText("Carregando...")).toBeInTheDocument();
+  });
+
+  it("maps icons for different sensor naming patterns", () => {
+    mockUseAssets.mockReturnValueOnce({
+      sensorAssets: [
+        { entity_id: "binary_sensor.janela", name: "Janela", is_active: true },
+        { entity_id: "binary_sensor.motion_hall", name: "Motion Hall", is_active: true },
+        { entity_id: "binary_sensor.smoke", name: "Smoke", is_active: true },
+        { entity_id: "binary_sensor.zigbee_status", name: "Zigbee Status", is_active: true },
+        { entity_id: "binary_sensor.generic", name: "Generic", is_active: true },
+      ],
+      assetsLoading: false,
+    });
+    render(<SensorGrid />);
+
+    expect(screen.getByText("🪟")).toBeInTheDocument();
+    expect(screen.getAllByText("👁").length).toBeGreaterThan(0);
+    expect(screen.getByText("🔥")).toBeInTheDocument();
+    expect(screen.getByText("📡")).toBeInTheDocument();
+    expect(screen.getByText("🔵")).toBeInTheDocument();
+  });
 });

--- a/src/dashboard/frontend/src/components/ServiceStatus.test.jsx
+++ b/src/dashboard/frontend/src/components/ServiceStatus.test.jsx
@@ -29,4 +29,18 @@ describe("ServiceStatus", () => {
     await waitFor(() => expect(global.fetch).toHaveBeenCalledWith("/api/services/status"));
     expect(screen.getByText("Verificando...")).toBeInTheDocument();
   });
+
+  it("renders unknown service key and unknown status fallback", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: async () => ({
+        services: {
+          custom_service: "mystery",
+        },
+      }),
+    });
+
+    render(<ServiceStatus />);
+    await waitFor(() => expect(screen.getByText("custom_service")).toBeInTheDocument());
+    expect(screen.getByText("mystery")).toBeInTheDocument();
+  });
 });

--- a/src/dashboard/frontend/src/hooks/useAssets.test.jsx
+++ b/src/dashboard/frontend/src/hooks/useAssets.test.jsx
@@ -123,4 +123,29 @@ describe("useAssets hook", () => {
       expect(result.current.assets).toHaveLength(2);
     });
   });
+
+  it("refetch accepts filters and appends query params", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ items: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ items: [] }),
+      });
+
+    const { result } = renderHook(() => useAssets());
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      result.current.refetch({ assetType: "sensor", isActive: false });
+    });
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2));
+    const secondUrl = global.fetch.mock.calls[1][0];
+    expect(secondUrl).toContain("asset_type=sensor");
+    expect(secondUrl).toContain("is_active=false");
+  });
 });

--- a/src/dashboard/frontend/src/pages/SimplifiedView.test.jsx
+++ b/src/dashboard/frontend/src/pages/SimplifiedView.test.jsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import SimplifiedView from "./SimplifiedView";
+
+const mockStore = {
+  states: {},
+};
+
+vi.mock("../store/useStore", () => ({
+  default: () => mockStore,
+}));
+
+vi.mock("../components/OperationalMap", () => ({
+  default: () => <div>Mapa Mock</div>,
+}));
+
+vi.mock("../components/CameraGrid", () => ({
+  default: () => <div>CameraGrid Mock</div>,
+}));
+
+describe("SimplifiedView", () => {
+  it("renders triggered status style and embedded components", () => {
+    mockStore.states = {
+      "alarm_control_panel.alarmo": { state: "triggered" },
+    };
+
+    render(<SimplifiedView />);
+    expect(screen.getByText("ALARME DISPARADO")).toBeInTheDocument();
+    expect(screen.getByText("Mapa Mock")).toBeInTheDocument();
+    expect(screen.getByText("CameraGrid Mock")).toBeInTheDocument();
+  });
+
+  it("falls back to disarmed config when alarm state is unknown", () => {
+    mockStore.states = {
+      "alarm_control_panel.alarmo": { state: "unknown_state" },
+    };
+
+    render(<SimplifiedView />);
+    expect(screen.getByText("Sistema Desarmado")).toBeInTheDocument();
+  });
+});

--- a/src/dashboard/frontend/src/store/useStore.test.js
+++ b/src/dashboard/frontend/src/store/useStore.test.js
@@ -73,6 +73,14 @@ describe("useStore actions", () => {
     expect(useStore.getState().assets[0].status).toBe("inactive");
   });
 
+  it("updateAsset keeps array untouched when id does not match", () => {
+    const original = { id: "1", name: "Sensor A", status: "active" };
+    useStore.setState({ assets: [original] });
+
+    useStore.getState().updateAsset({ id: "2", name: "Outro", status: "inactive" });
+    expect(useStore.getState().assets).toEqual([original]);
+  });
+
   it("removeAsset removes asset by id", () => {
     const assets = [
       { id: "1", name: "Sensor A" },

--- a/tests/backend/test_assets_router_coverage.py
+++ b/tests/backend/test_assets_router_coverage.py
@@ -155,6 +155,28 @@ async def test_create_asset_conflict_raises_409():
 
 
 @pytest.mark.anyio
+async def test_create_asset_success_creates_asset_and_audit():
+    db = _DbQueue([_Result(one_or_none=None)])
+    payload = AssetCreate(
+        asset_type="camera",
+        name="Cam Entrada",
+        entity_id="camera.entrada",
+        status="active",
+        location="entrada",
+        description="camera frontal",
+        config_json='{"fps":15}',
+    )
+    result = await create_asset(payload=payload, request=_request(actor="admin"), db=db)
+
+    assert result["entity_id"] == "camera.entrada"
+    assert result["name"] == "Cam Entrada"
+    assert db.flushed == 1
+    assert db.commits == 1
+    assert db.refreshed == 1
+    assert len(db.added) >= 2
+
+
+@pytest.mark.anyio
 async def test_update_asset_not_found_raises_404():
     db = _DbQueue([_Result(one_or_none=None)])
     with pytest.raises(HTTPException) as exc:
@@ -205,3 +227,33 @@ async def test_restore_asset_not_found_raises_404():
     with pytest.raises(HTTPException) as exc:
         await restore_asset(asset_id=uuid.uuid4(), request=_request(), db=db)
     assert exc.value.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_delete_asset_success_soft_deactivates_and_returns_status():
+    asset = _asset()
+    db = _DbQueue([_Result(one_or_none=asset)])
+
+    result = await delete_asset(asset_id=asset.id, request=_request(actor="admin"), db=db)
+
+    assert result["status"] == "deactivated"
+    assert result["id"] == str(asset.id)
+    assert asset.is_active is False
+    assert asset.status == "inactive"
+    assert db.commits == 1
+
+
+@pytest.mark.anyio
+async def test_restore_asset_success_reactivates_and_returns_asset():
+    asset = _asset()
+    asset.status = "inactive"
+    asset.is_active = False
+    db = _DbQueue([_Result(one_or_none=asset)])
+
+    result = await restore_asset(asset_id=asset.id, request=_request(actor="admin"), db=db)
+
+    assert result["id"] == str(asset.id)
+    assert result["status"] == "active"
+    assert result["is_active"] is True
+    assert db.commits == 1
+    assert db.refreshed == 1


### PR DESCRIPTION
## Objetivo
Elevar cobertura do dashboard para meta de 100% de linhas no escopo medido pelo Sonar.

## O que foi feito
- Adicionados testes de cobertura para componentes de UI e páginas:
  - Header.test.jsx
  - SimplifiedView.test.jsx
  - DroneStatus.test.jsx
- Expandida cobertura dos testes existentes:
  - AlertFeed.test.jsx
  - CameraGrid.test.jsx
  - ServiceStatus.test.jsx
  - QuickActionsMenu.test.jsx
  - SensorGrid.test.jsx
  - useAssets.test.jsx
  - useStore.test.js
- Expandida cobertura backend para assets.py com cenários de sucesso de create/delete/restore:
  - tests/backend/test_assets_router_coverage.py

## Validação local
- Frontend (npm run test:coverage):
  - All files %Lines = 100
- Backend (pytest --cov=app.routers.assets):
  - assets.py = 100%

## Observações
- O script local de Sonar requer SONAR_TOKEN no ambiente; validação final do quality gate ocorre no CI.
