### PR TITLE
docs: definir SLOs e SLAs dos serviços críticos

### DIFF
--- a/docs/SLOS_SLAS_CRITICAL_SERVICES.md
+++ b/docs/SLOS_SLAS_CRITICAL_SERVICES.md
@@ -3,6 +3,11 @@
 ## Objetivo
 Definir metas operacionais mínimas para disponibilidade e recuperação.
 
+## Escopo e vigência
+- Vigência inicial: 2026-03-01 até 2026-08-31.
+- Revisão obrigatória: semestral ou após 2 incidentes P1 no mesmo serviço.
+- Ambiente de medição: produção (K3s), com validação de tendência em homol.
+
 ## Serviços críticos
 - Home Assistant
 - Mosquitto MQTT
@@ -11,29 +16,44 @@ Definir metas operacionais mínimas para disponibilidade e recuperação.
 - Dashboard API
 
 ## SLOs
-| Serviço | SLI | SLO mensal |
+| Serviço | SLI | Janela | SLO |
 |---|---|---|
-| Home Assistant | Disponibilidade HTTP | >= 99.5% |
-| Mosquitto | Disponibilidade broker | >= 99.9% |
-| PostgreSQL | Disponibilidade de conexão | >= 99.9% |
-| Frigate | Disponibilidade de UI/API | >= 99.0% |
-| Dashboard API | Disponibilidade `/health` | >= 99.5% |
+| Home Assistant | Disponibilidade HTTP (2xx/3xx em `/`) | 30 dias corridos | >= 99.5% |
+| Mosquitto | Disponibilidade broker (connect + publish + subscribe) | 30 dias corridos | >= 99.9% |
+| PostgreSQL | Disponibilidade de conexão (probe SQL) | 30 dias corridos | >= 99.9% |
+| Frigate | Disponibilidade de UI/API (HTTP + stream ativo) | 30 dias corridos | >= 99.0% |
+| Dashboard API | Disponibilidade de `/health` e latência p95 de `/api/services/status` | 30 dias corridos | >= 99.5% e p95 <= 350 ms |
 
 ## SLAs operacionais internos
 - Incidente P1: início de resposta <= 15 min.
 - Incidente P1: restauração parcial <= 60 min.
 - Incidente P1: restauração total <= 4 h.
 - Incidente P2: resposta <= 4 h úteis.
+- Comunicação interna de incidente P1: primeira atualização em <= 30 min.
 
 ## Error budget
-- Home Assistant (99.5%): ~3h39m de indisponibilidade/mês.
-- Serviços 99.9%: ~43m de indisponibilidade/mês.
+- Home Assistant e Dashboard API (99.5%): ~3h39m de indisponibilidade/mês.
+- Mosquitto e PostgreSQL (99.9%): ~43m de indisponibilidade/mês.
+- Frigate (99.0%): ~7h18m de indisponibilidade/mês.
+
+## Método de medição (SLI)
+- Coleta primária por healthchecks e métricas dos serviços.
+- Frequência de coleta: 60s para disponibilidade, 30s para latência em endpoints HTTP.
+- Regra de cálculo de disponibilidade: `success / total` por janela móvel de 30 dias.
+- Regra de latência: percentil p95 no período, com exclusão de janelas de manutenção aprovada.
+
+## Fontes de evidência
+- Dashboard operacional (`ServiceStatus`) para status corrente.
+- Logs de aplicação e plataforma (`docker compose logs` / `kubectl logs`) para auditoria.
+- Histórico de incidentes e post-mortem em `docs/INCIDENT_RESPONSE.md`.
 
 ## Observabilidade mínima
 - Healthchecks ativos em Compose/K8s.
 - Logs centralizados por serviço.
 - Teste de restore PostgreSQL trimestral.
+- Alerta automático quando uso do error budget exceder 50% no mês.
 
 ## Governança
 - Revisão semestral de metas.
 - Ajuste de SLO condicionado a capacidade operacional e histórico de incidentes.
+- Qualquer flexibilização de SLO exige ADR ou registro formal de exceção com prazo.

--- a/wiki/Operacao-e-Manutencao.md
+++ b/wiki/Operacao-e-Manutencao.md
@@ -81,6 +81,11 @@ Transição de drones mock -> hardware: `docs/DRONES_MOCK_TO_HARDWARE_RUNBOOK.md
 
 Metas operacionais (SLO/SLA): `docs/SLOS_SLAS_CRITICAL_SERVICES.md`
 
+Resumo operacional:
+- Janela de medição padrão dos SLOs: 30 dias corridos.
+- Alerta preventivo quando o consumo do error budget atingir 50% no mês.
+- Revisão formal das metas a cada semestre ou após recorrência de P1.
+
 ## Hardening e resiliência
 
 - Consulte `docs/HARDENING_ANTI_TAMPER.md` para configurações de segurança


### PR DESCRIPTION
## Resumo\n- detalha SLO/SLI por serviço crítico com janela de medição\n- adiciona critérios de governança, error budget e fontes de evidência\n- atualiza wiki operacional com resumo de monitoramento\n\n## Testes\n- .venv/bin/pytest tests/backend -q\n\nCloses #620