### PR TITLE
docs: estruturar CHANGELOG com release versionada

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 Todas as mudanças relevantes deste projeto serão registradas neste arquivo.
 
-O formato segue Keep a Changelog e versionamento semântico.
+O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/)
+e [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
 ## [Unreleased]
+
+### Changed
+- Padronização do changelog com versão publicada e regras de atualização.
+
+## [0.1.0] - 2026-02-24
 
 ### Added
 - Runbook de backup e restore do PostgreSQL em `docs/POSTGRES_BACKUP_RESTORE_RUNBOOK.md`.
@@ -20,3 +26,6 @@ O formato segue Keep a Changelog e versionamento semântico.
 - `mosquitto` adiciona listener loopback para TLS em `127.0.0.1:8883` e seleção de configuração por `APP_ENV`.
 - Dependências dos drones fixadas com versões exatas (`==`).
 - Configuração do Dependabot atualizada para ecossistemas reais do repositório.
+
+[unreleased]: https://github.com/rodrigobprado/Home-Security-DIY/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/rodrigobprado/Home-Security-DIY/releases/tag/v0.1.0

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -61,6 +61,7 @@ O projeto combina automação, vídeo inteligente, sensores e drones para segura
 ## Documentação no repositório
 
 - `README.md` — visão geral e quickstart
+- `CHANGELOG.md` — histórico versionado de mudanças por release
 - `docs/` — arquitetura, hardening, threat model, ADRs
 - `docs/*RUNBOOK*.md` — guias operacionais de manutenção e recuperação
 - `prd/` — Product Requirements Documents


### PR DESCRIPTION
## Resumo
- padroniza `CHANGELOG.md` no formato Keep a Changelog
- adiciona release `0.1.0` com data e links de comparação
- inclui referência ao changelog na wiki principal

## Testes
- .venv/bin/pytest tests/backend -q

Closes #619
