### PR TITLE
chore(drones): fixar versões de dependências opcionais

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ e [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
 ### Changed
 - Padronização do changelog com versão publicada e regras de atualização.
+- Dependência opcional `pymavlink` dos drones documentada com versão fixa (`==`) para manter reprodutibilidade quando habilitada.
 
 ## [0.1.0] - 2026-02-24
 

--- a/src/drones/common/requirements.txt
+++ b/src/drones/common/requirements.txt
@@ -2,4 +2,4 @@ paho-mqtt==1.6.1
 pyserial==3.5
 opencv-python-headless==4.8.0.76 # For UGV vision
 numpy==1.24.4 # For UGV vision
-# pymavlink>=2.4.37 # Uncomment when using real MAVLink
+# pymavlink==2.4.37 # Uncomment when using real MAVLink

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -58,6 +58,7 @@ O projeto combina automação, vídeo inteligente, sensores e drones para segura
 - ADRs 005-010 formalizados em `docs/adr/`.
 - Changelog versionado na raiz do projeto (`CHANGELOG.md`).
 - Estratégia de secrets no Kubernetes com External Secrets em produção (`k8s/overlays/production/external-secrets.yaml`).
+- Dependências dos drones totalmente pinadas (`==`), incluindo dependências opcionais comentadas para ativação futura.
 
 ## Documentação no repositório
 


### PR DESCRIPTION
## Resumo
- fixa dependência opcional comentada (`pymavlink`) em `src/drones/common/requirements.txt` de `>=` para `==`
- mantém build reproduzível mesmo quando a dependência for habilitada no futuro
- atualiza changelog e wiki com o ajuste

## Testes
- .venv/bin/pytest tests/backend -q

Closes #617
