### PR TITLE
docs: detalhar atualização do Home Assistant sem downtime

### DIFF
--- a/docs/HOME_ASSISTANT_ZERO_DOWNTIME_UPDATE_RUNBOOK.md
+++ b/docs/HOME_ASSISTANT_ZERO_DOWNTIME_UPDATE_RUNBOOK.md
@@ -6,11 +6,17 @@ Atualizar Home Assistant minimizando indisponibilidade operacional.
 ## Estratégia
 Blue/Green lógico com validação prévia e rollback rápido.
 
+## Escopo
+- Ambiente Docker Compose (desenvolvimento/homologação).
+- Ambiente K3s (produção).
+- Fluxo com canário curto, smoke tests e rollback imediato.
+
 ## Pré-check
 1. Confirmar backup recente de configuração.
 2. Confirmar banco PostgreSQL saudável.
 3. Validar integração MQTT e Frigate.
 4. Anunciar janela de mudança.
+5. Registrar versão atual (`docker inspect` ou `kubectl get deploy`).
 
 ## Procedimento (Compose)
 1. Baixar imagem nova sem trocar container ativo:
@@ -32,14 +38,51 @@ curl -fsS http://localhost:8123/ >/dev/null
 ```
 5. Validar automações críticas (alarme, MQTT, notificações).
 
+## Procedimento (K3s / Produção)
+1. Atualizar tag da imagem no deployment:
+```bash
+kubectl -n home-security set image deploy/homeassistant homeassistant=ghcr.io/home-assistant/home-assistant:<nova-tag>
+```
+2. Acompanhar rollout:
+```bash
+kubectl -n home-security rollout status deploy/homeassistant --timeout=180s
+```
+3. Verificar readiness e eventos:
+```bash
+kubectl -n home-security get pods -l app=homeassistant -o wide
+kubectl -n home-security describe deploy/homeassistant
+```
+4. Executar smoke tests pós-rollout:
+```bash
+curl -fsS https://homeassistant-home-security.toca.lan/ >/dev/null
+curl -fsS http://localhost:8000/api/services/status >/dev/null
+```
+
 ## Rollback
 1. Reverter para imagem anterior conhecida.
 2. Subir container com tag anterior.
 3. Restaurar snapshot caso necessário.
 
+### Rollback Compose
+```bash
+cd src
+docker compose up -d --no-deps homeassistant
+```
+
+### Rollback K3s
+```bash
+kubectl -n home-security rollout undo deploy/homeassistant
+kubectl -n home-security rollout status deploy/homeassistant --timeout=180s
+```
+
 ## SLO de mudança
 - Downtime máximo aceitável: 2 minutos.
 - Tempo máximo de rollback: 5 minutos.
+
+## Critérios de sucesso
+- Serviço com `healthcheck` estável por 10 minutos após mudança.
+- `ServiceStatus` no dashboard sem degradação para Home Assistant.
+- Fluxos críticos funcionando: arme/desarme, eventos MQTT e webhook de alerta.
 
 ## Evidência obrigatória
 - Versão anterior/nova

--- a/wiki/Operacao-e-Manutencao.md
+++ b/wiki/Operacao-e-Manutencao.md
@@ -77,6 +77,12 @@ kubectl rollout restart deployment/dashboard-frontend -n home-security
 
 Atualização controlada do Home Assistant: `docs/HOME_ASSISTANT_ZERO_DOWNTIME_UPDATE_RUNBOOK.md`
 
+Checklist mínimo para mudança sem downtime (Home Assistant):
+- validar backup + saúde do PostgreSQL antes da troca
+- executar `check_config` antes do restart/rollout
+- validar smoke test HTTP e integrações críticas após atualização
+- manter rollback pronto (`docker compose` ou `kubectl rollout undo`)
+
 Transição de drones mock -> hardware: `docs/DRONES_MOCK_TO_HARDWARE_RUNBOOK.md`
 
 Metas operacionais (SLO/SLA): `docs/SLOS_SLAS_CRITICAL_SERVICES.md`


### PR DESCRIPTION
## Resumo
- amplia o runbook de atualização do Home Assistant sem downtime para Compose e K3s
- adiciona passos de pré-check, rollout, smoke tests e rollback operacional
- atualiza wiki de operação com checklist mínimo da mudança

## Testes
- .venv/bin/pytest tests/backend -q

Closes #616
Closes #620
