### PR TITLE
docs: expandir runbook de backup e restore do PostgreSQL

### DIFF
--- a/docs/POSTGRES_BACKUP_RESTORE_RUNBOOK.md
+++ b/docs/POSTGRES_BACKUP_RESTORE_RUNBOOK.md
@@ -11,6 +11,7 @@ Garantir backup consistente e restauração validada do banco PostgreSQL do proj
 - Stack em execução (`docker compose` ou K8s)
 - Acesso ao usuário administrador do PostgreSQL
 - Chave de criptografia configurada (`BACKUP_ENCRYPTION_PASSPHRASE`)
+- Espaço em disco local >= 2x tamanho estimado do dump
 
 ## Backup (Docker Compose)
 1. Executar dump completo:
@@ -28,6 +29,15 @@ openssl enc -aes-256-cbc -salt -pbkdf2 -in /tmp/homedb_*.dump -out /tmp/homedb_*
 ```
 4. Copiar para armazenamento externo/offsite.
 
+## Backup (K3s)
+1. Executar dump no pod PostgreSQL:
+```bash
+kubectl -n home-security exec -i statefulset/postgres -- \
+  pg_dump -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-homedb}" -Fc > /tmp/homedb_$(date +%F_%H%M).dump
+```
+2. Gerar checksum e criptografar (mesmos comandos da seção Docker).
+3. Publicar artefato em armazenamento externo versionado.
+
 ## Restore (ambiente de teste)
 1. Subir banco limpo.
 2. Restaurar dump:
@@ -40,6 +50,28 @@ docker compose exec -T postgres pg_restore -U "${POSTGRES_USER:-postgres}" -d re
 ```bash
 docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d restore_validation -c "\dn"
 ```
+
+## Restore (K3s em homologação)
+1. Criar banco de validação:
+```bash
+kubectl -n home-security exec -i statefulset/postgres -- \
+  createdb -U "${POSTGRES_USER:-postgres}" restore_validation || true
+```
+2. Restaurar dump:
+```bash
+kubectl -n home-security exec -i statefulset/postgres -- \
+  pg_restore -U "${POSTGRES_USER:-postgres}" -d restore_validation < /tmp/homedb_YYYY-MM-DD_HHMM.dump
+```
+3. Validar schemas:
+```bash
+kubectl -n home-security exec -i statefulset/postgres -- \
+  psql -U "${POSTGRES_USER:-postgres}" -d restore_validation -c "\dn"
+```
+
+## Guardrails de restauração em produção
+- Restore direto em produção exige aprovação explícita e janela de manutenção.
+- Antes do restore, capturar snapshot atual para rollback.
+- Após restore, executar smoke test da Dashboard API e integrações MQTT.
 
 ## RPO/RTO alvo
 - RPO: até 24h
@@ -54,3 +86,9 @@ docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d restore_
 - Checksum válido.
 - Restore executado e schemas visíveis.
 - Evidência registrada em `tasks/` com data/hora.
+
+## Evidência mínima a registrar
+- Data/hora de início e término.
+- Nome do artefato de backup e hash SHA-256.
+- Ambiente validado (Compose/K3s) e resultado de restore.
+- Desvio de RPO/RTO (se houver) e ação corretiva.

--- a/wiki/Operacao-e-Manutencao.md
+++ b/wiki/Operacao-e-Manutencao.md
@@ -63,6 +63,12 @@ kubectl exec -n home-security postgres-0 -- psql -U postgres homedb < backup.sql
 
 Runbook detalhado: `docs/POSTGRES_BACKUP_RESTORE_RUNBOOK.md`
 
+Checklist de validação trimestral (PostgreSQL):
+- gerar dump completo + checksum
+- testar restore em banco `restore_validation`
+- confirmar schemas críticos (`homeassistant`, `dashboard`, `metrics`)
+- registrar evidência de RPO/RTO atingidos
+
 ## Atualização de serviços
 
 ```bash


### PR DESCRIPTION
## Resumo
- expande runbook de backup/restore PostgreSQL para Docker Compose e K3s
- adiciona guardrails para restore em produção e critérios de evidência
- atualiza wiki de operação com checklist trimestral de validação

## Testes
- .venv/bin/pytest tests/backend -q

Closes #615
