### PR TITLE
docs(k8s): adotar External Secrets como padrão de produção

### DIFF
--- a/docs/K8S_SECRETS_MANAGEMENT.md
+++ b/docs/K8S_SECRETS_MANAGEMENT.md
@@ -7,6 +7,16 @@ Eliminar o uso operacional de segredos em texto plano nos manifests aplicados em
 - Produção: External Secrets Operator (ESO)
 - Desenvolvimento/local: placeholders permitidos apenas para bootstrap
 
+## Decisão técnica (ESO vs SealedSecrets)
+| Critério | External Secrets (adotado) | SealedSecrets |
+|---|---|---|
+| Rotação centralizada | Nativa no backend de secrets | Requer novo selo + commit |
+| Exposição em Git | Apenas referência ao segredo remoto | Ciphertext versionado no repositório |
+| Operação multiambiente | Mais simples com stores por ambiente | Exige gestão de chaves por cluster |
+| Dependências | Operador + backend de segredos | Operador + chave de selagem |
+
+Decisão: manter ESO como padrão de produção para reduzir acoplamento de segredo ao Git e facilitar rotação.
+
 ## Arquivos relevantes
 - `k8s/overlays/production/external-secrets.yaml`
 - `k8s/overlays/production/kustomization.yaml`
@@ -23,6 +33,7 @@ Eliminar o uso operacional de segredos em texto plano nos manifests aplicados em
 - Não commitar valores reais de credenciais.
 - Rotacionar segredos críticos trimestralmente.
 - Bloquear merge se for detectado token/senha real em PR.
+- Em produção, não aplicar Secret manual com valor em claro quando existir `ExternalSecret` equivalente.
 
 ## Validação rápida
 ```bash

--- a/tests/backend/test_k8s_external_secrets_contract.py
+++ b/tests/backend/test_k8s_external_secrets_contract.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PROD_KUSTOMIZATION = ROOT / "k8s" / "overlays" / "production" / "kustomization.yaml"
+PROD_EXTERNAL_SECRETS = ROOT / "k8s" / "overlays" / "production" / "external-secrets.yaml"
+SECRETS_DOC = ROOT / "docs" / "K8S_SECRETS_MANAGEMENT.md"
+
+
+def test_production_overlay_includes_external_secrets_manifest():
+    content = PROD_KUSTOMIZATION.read_text(encoding="utf-8")
+
+    assert "external-secrets.yaml" in content
+
+
+def test_external_secrets_manifest_declares_required_resources():
+    content = PROD_EXTERNAL_SECRETS.read_text(encoding="utf-8")
+
+    assert "kind: SecretStore" in content
+    assert "kind: ExternalSecret" in content
+    assert "name: dashboard-credentials" in content
+    assert "name: frigate-cameras" in content
+
+
+def test_secrets_management_doc_sets_eso_as_production_standard():
+    content = SECRETS_DOC.read_text(encoding="utf-8")
+
+    assert "External Secrets Operator" in content
+    assert "Produção" in content

--- a/wiki/Seguranca-e-Compliance.md
+++ b/wiki/Seguranca-e-Compliance.md
@@ -83,7 +83,7 @@ Em fevereiro de 2026 foi realizada uma auditoria red team completa do codebase. 
 | **Nginx** | Security headers completos: `Content-Security-Policy`, `HSTS`, `X-Frame-Options: DENY`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`. | #16 |
 | **Docker Compose** | Portas MQTT, Zigbee2MQTT e Frigate vinculadas a loopback (`127.0.0.1`). Healthcheck do Mosquitto sem credenciais expostas. Versões de imagens fixadas em semver. | #10, #12, #20, #23 |
 | **Credenciais** | `admin:password` das câmeras substituídos por `CHANGE_ME_*` em todos os arquivos (`.env.example`, K8s Secret do Frigate). | #29, #77 |
-| **Scripts K8s** | `generate-k8s-secrets.sh` gera Secrets localmente a partir do `.env`, nunca commitados. `DASHBOARD_API_KEY` adicionado. | #13 |
+| **Scripts K8s** | `generate-k8s-secrets.sh` gera Secrets localmente a partir do `.env`. Em produção, padrão operacional é `External Secrets Operator` (`k8s/overlays/production/external-secrets.yaml`). | #13, #613 |
 | **MQTT TLS** | Bloco TLS comentado adicionado ao `mosquitto.conf` (porta 8883). Script `generate-mqtt-certs.sh` gera CA + certificado auto-assinado. | #10 |
 | **Home Assistant** | `trusted_proxies` restrito a `127.0.0.1` e `172.17.0.1`. Recorder usando PostgreSQL via `!env_var`. | #18, #25 |
 | **K8s / CI** | Ingress com TLS (`home-security-tls`). Snyk CI com paths corretos. | #24, #27 |


### PR DESCRIPTION
## Resumo
- documenta formalmente a decisão de usar External Secrets Operator em produção
- adiciona matriz de decisão ESO vs SealedSecrets e regra operacional para evitar secrets em claro
- cria teste de contrato para garantir presença de `external-secrets.yaml` no overlay de produção
- atualiza wiki de segurança/compliance com o padrão adotado

## Testes
- .venv/bin/pytest -q tests/backend/test_k8s_external_secrets_contract.py tests/backend

Closes #613
