### PR TITLE
chore(deps): reforçar configuração do Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,42 +7,136 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "main"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/Sao_Paulo"
     open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "docker"
     directory: "/src"
+    target-branch: "main"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "06:10"
+      timezone: "America/Sao_Paulo"
     open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      docker-images:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/src/dashboard/backend"
+    target-branch: "main"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "06:20"
+      timezone: "America/Sao_Paulo"
     open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      dashboard-backend-pip:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/src/drones/common"
+    target-branch: "main"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "06:30"
+      timezone: "America/Sao_Paulo"
     open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"
+      - "drones"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      drones-common-pip:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/src/drones/ugv/app"
+    target-branch: "main"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "06:35"
+      timezone: "America/Sao_Paulo"
     open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"
+      - "drones"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      drones-ugv-pip:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/src/drones/uav"
+    target-branch: "main"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "06:40"
+      timezone: "America/Sao_Paulo"
     open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"
+      - "drones"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      drones-uav-pip:
+        patterns:
+          - "*"
 
   - package-ecosystem: "npm"
     directory: "/src/dashboard/frontend"
+    target-branch: "main"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "06:50"
+      timezone: "America/Sao_Paulo"
     open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "frontend"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      dashboard-frontend-npm:
+        patterns:
+          - "*"

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -93,6 +93,12 @@ python3 -m venv .venv
 .venv/bin/pytest -q tests/backend
 ```
 
+### 3.6 Dependabot e atualizações automáticas
+
+- O repositório usa Dependabot com execução semanal para `github-actions`, `docker`, `pip` e `npm`.
+- PRs de dependências recebem labels automáticas para triagem rápida.
+- Alterações na política ficam em `.github/dependabot.yml`.
+
 ---
 
 ## 4. Como contribuir

--- a/tests/backend/test_dependabot_config_contract.py
+++ b/tests/backend/test_dependabot_config_contract.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEPENDABOT_CONFIG = ROOT / ".github" / "dependabot.yml"
+
+
+def test_dependabot_config_covers_required_ecosystems_and_paths():
+    content = DEPENDABOT_CONFIG.read_text(encoding="utf-8")
+
+    expected_pairs = [
+        ('package-ecosystem: "github-actions"', 'directory: "/"'),
+        ('package-ecosystem: "docker"', 'directory: "/src"'),
+        ('package-ecosystem: "pip"', 'directory: "/src/dashboard/backend"'),
+        ('package-ecosystem: "pip"', 'directory: "/src/drones/common"'),
+        ('package-ecosystem: "pip"', 'directory: "/src/drones/ugv/app"'),
+        ('package-ecosystem: "pip"', 'directory: "/src/drones/uav"'),
+        ('package-ecosystem: "npm"', 'directory: "/src/dashboard/frontend"'),
+    ]
+
+    for ecosystem, directory in expected_pairs:
+        assert ecosystem in content
+        assert directory in content
+
+
+def test_dependabot_config_enforces_main_branch_weekly_schedule_and_labels():
+    content = DEPENDABOT_CONFIG.read_text(encoding="utf-8")
+
+    assert 'target-branch: "main"' in content
+    assert 'interval: "weekly"' in content
+    assert 'timezone: "America/Sao_Paulo"' in content
+    assert 'labels:' in content

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -59,6 +59,7 @@ O projeto combina automação, vídeo inteligente, sensores e drones para segura
 - Changelog versionado na raiz do projeto (`CHANGELOG.md`).
 - Estratégia de secrets no Kubernetes com External Secrets em produção (`k8s/overlays/production/external-secrets.yaml`).
 - Dependências dos drones totalmente pinadas (`==`), incluindo dependências opcionais comentadas para ativação futura.
+- Dependabot padronizado para `github-actions`, Docker, pip e npm com agenda semanal e labels de triagem.
 
 ## Documentação no repositório
 


### PR DESCRIPTION
## Resumo
- fortalece `.github/dependabot.yml` com target branch, timezone, labels, commit message e grupos por ecossistema
- documenta política de updates automáticos em `docs/ONBOARDING.md`
- atualiza wiki com registro da governança de dependências
- adiciona teste de contrato para garantir cobertura dos ecossistemas e baseline de schedule

## Testes
- .venv/bin/pytest -q tests/backend/test_dependabot_config_contract.py tests/backend

Closes #612
