### PR TITLE
docs(security): completar responsible disclosure

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,12 +49,40 @@ Inclua no report:
 
 Nós nos comprometemos a responder em até 48 horas.
 
+### SLA de resposta por severidade
+
+| Severidade | Confirmação inicial | Mitigação/Plano | Janela alvo de correção |
+|---|---|---|---|
+| Crítica | até 24h | até 48h | até 7 dias corridos |
+| Alta | até 48h | até 5 dias corridos | até 14 dias corridos |
+| Média | até 5 dias corridos | até 10 dias corridos | até 30 dias corridos |
+| Baixa | até 7 dias corridos | até 20 dias corridos | próxima release planejada |
+
+## Escopo de reporte
+
+### Em escopo
+- API e frontend do dashboard (`src/dashboard/**`)
+- Manifests Docker/K8s e scripts de deploy (`src/docker-compose.yml`, `k8s/**`, `scripts/**`)
+- Configurações e integrações críticas de segurança (MQTT, Home Assistant, Frigate)
+
+### Fora de escopo
+- Ataques de engenharia social sem vulnerabilidade técnica comprovada
+- Vulnerabilidades dependentes exclusivamente de configuração local insegura já documentada
+- Falhas em hardware/firmware de terceiros sem relação direta com este repositório
+
 ## Processo de Resposta
 
 1. **Triagem**: Analisaremos o report para confirmar a vulnerabilidade e determinar sua severidade.
 2. **Correção**: Desenvolveremos um patch de correção em um branch privado.
 3. **Validação**: Testaremos a correção para garantir que não introduza regressões.
 4. **Divulgação**: Publicaremos a correção e um Security Advisory detalhando o problema (após a mitigação estar disponível).
+
+## Política de divulgação e crédito
+
+- Não divulgar detalhes exploráveis antes de patch/mitigação disponível.
+- Após correção, publicar advisory com versão afetada, versão corrigida, impacto e recomendação.
+- Pesquisadores que desejarem serão creditados no advisory.
+- CVE poderá ser solicitado quando aplicável ao impacto e ao ecossistema.
 
 ## Boas Práticas de Segurança para Usuários
 

--- a/tests/backend/test_security_policy_contract.py
+++ b/tests/backend/test_security_policy_contract.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SECURITY_POLICY = ROOT / "SECURITY.md"
+
+
+def test_security_policy_includes_private_reporting_channel():
+    content = SECURITY_POLICY.read_text(encoding="utf-8")
+
+    assert "NÃO abra uma issue pública" in content
+    assert "/security/advisories/new" in content
+
+
+def test_security_policy_defines_sla_by_severity():
+    content = SECURITY_POLICY.read_text(encoding="utf-8")
+
+    assert "SLA de resposta por severidade" in content
+    assert "Crítica" in content
+    assert "Alta" in content
+    assert "Média" in content
+    assert "Baixa" in content

--- a/wiki/Seguranca-e-Compliance.md
+++ b/wiki/Seguranca-e-Compliance.md
@@ -4,6 +4,12 @@ O sistema Home Security DIY adota **defesa em profundidade** em duas dimensões:
 
 ---
 
+## Responsible Disclosure
+
+- Política oficial em `SECURITY.md`.
+- Canal privado para reporte: GitHub Security Advisory (`/security/advisories/new`).
+- SLA de resposta definido por severidade (Crítica/Alta/Média/Baixa) com prazos de confirmação e correção.
+
 ## Princípios
 
 | Princípio | Descrição |


### PR DESCRIPTION
## Resumo
- completa `SECURITY.md` com responsible disclosure, SLA por severidade e escopo de reporte
- adiciona política de divulgação coordenada e critérios de advisory pós-correção
- atualiza wiki de Segurança/Compliance com referência ao fluxo de reporte privado
- adiciona teste de contrato para prevenir regressão da política de segurança

## Testes
- .venv/bin/pytest -q tests/backend/test_security_policy_contract.py tests/backend

Closes #610
