### PR TITLE
docs(drones): completar runbook de transição mock→hardware

### DIFF
--- a/docs/DRONES_MOCK_TO_HARDWARE_RUNBOOK.md
+++ b/docs/DRONES_MOCK_TO_HARDWARE_RUNBOOK.md
@@ -7,6 +7,7 @@ Migrar o módulo de drones de simulação para operação em hardware real com r
 1. **Lab fechado**: validar sensores, atuadores e telemetria sem armamento real.
 2. **Shadow mode**: hardware ligado, comandos reais bloqueados por política.
 3. **Go-live restrito**: janela operacional limitada, geofence ativa.
+4. **Operação assistida**: liberar comandos críticos apenas com observador humano.
 
 ## Checklist pré-transição
 - [ ] HMAC habilitado para comandos (`COMMAND_HMAC_SECRET_*`).
@@ -28,12 +29,28 @@ docker compose --profile drones up -d ugv uav
 3. Executar comandos de teste assinados (`stop`, `return_home`).
 4. Validar trilhas de auditoria de defesa (`ugv/defense/audit`).
 
+## Procedimento (K3s / Produção)
+1. Confirmar deployment de UGV/UAV no namespace `home-security`.
+2. Aplicar configuração de hardware real (sem mocks) com rollout controlado.
+3. Executar smoke test operacional:
+   - publicação de `status` periódica em `ugv/status` e `uav/status`
+   - comando assinado `return_home` com confirmação de execução
+   - telemetria mínima: bateria, posição e modo de operação
+4. Monitorar 30 minutos sem perda de heartbeat antes de liberar operação assistida.
+
 ## Critérios de go-live
 - 0 comandos não assinados aceitos em produção.
 - Failover Wi-Fi -> LoRa observado e funcional.
 - Sem violação de geofence/altitude em 7 dias de shadow mode.
+- Observabilidade ativa (logs + eventos MQTT + dashboard).
 
 ## Rollback
 - Voltar para mock: desligar profile `drones`.
 - Bloquear comandos em automações HA.
 - Registrar incidente e lições aprendidas.
+
+## Evidência obrigatória
+- Data/hora da mudança e responsáveis.
+- Resultado de smoke tests (comandos assinados e failover).
+- Registro de geofence/altitude sem violação durante shadow mode.
+- Plano executado de rollback (quando aplicável).

--- a/tests/backend/test_drone_mock_to_hardware_runbook_contract.py
+++ b/tests/backend/test_drone_mock_to_hardware_runbook_contract.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNBOOK = ROOT / "docs" / "DRONES_MOCK_TO_HARDWARE_RUNBOOK.md"
+
+
+def test_runbook_covers_shadow_mode_and_golive_criteria():
+    content = RUNBOOK.read_text(encoding="utf-8")
+
+    assert "Shadow mode" in content
+    assert "Critérios de go-live" in content
+    assert "0 comandos não assinados aceitos em produção" in content
+
+
+def test_runbook_covers_rollback_and_required_evidence():
+    content = RUNBOOK.read_text(encoding="utf-8")
+
+    assert "## Rollback" in content
+    assert "## Evidência obrigatória" in content

--- a/wiki/Drones-Autonomos.md
+++ b/wiki/Drones-Autonomos.md
@@ -269,6 +269,7 @@ REGRA-DRONE-10: Whitelist de pessoas autorizadas deve ser configurável.
 - `docs/ARQUITETURA_DRONES_AUTONOMOS.md` — fonte principal desta página
 - `docs/ARQUITETURA_HARDWARE_UGV.md` — especificações detalhadas do UGV
 - `docs/ARQUITETURA_HARDWARE_UAV.md` — especificações detalhadas do UAV
+- `docs/DRONES_MOCK_TO_HARDWARE_RUNBOOK.md` — transição segura de mock para hardware real
 - `docs/LEGAL_AND_ETHICS.md` — aspectos legais e éticos
 - `prd/PRD_AUTONOMOUS_DRONES.md` — requisitos detalhados
 - [PX4 Autopilot](https://px4.io/) | [ROS2](https://docs.ros.org/) | [Nav2](https://nav2.org/)


### PR DESCRIPTION
## Resumo
- expande o runbook de transição mock→hardware real para drones com etapas de produção (K3s)
- reforça critérios de go-live, rollback e evidências operacionais obrigatórias
- adiciona referência direta na wiki de drones
- inclui teste de contrato para prevenir regressão do runbook

## Testes
- .venv/bin/pytest -q tests/backend/test_drone_mock_to_hardware_runbook_contract.py tests/backend

Closes #609
