### PR TITLE
test(compose): garantir profile de drones no docker-compose

### DIFF
--- a/tests/backend/test_drones_compose_profile_contract.py
+++ b/tests/backend/test_drones_compose_profile_contract.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+COMPOSE = ROOT / "src" / "docker-compose.yml"
+
+
+def test_compose_defines_ugv_and_uav_services_in_drones_profile():
+    content = COMPOSE.read_text(encoding="utf-8")
+
+    assert "ugv:" in content
+    assert "uav:" in content
+    assert content.count('profiles: ["drones"]') >= 2

--- a/wiki/Operacao-e-Manutencao.md
+++ b/wiki/Operacao-e-Manutencao.md
@@ -91,6 +91,12 @@ Checklist mínimo para mudança sem downtime (Home Assistant):
 
 Transição de drones mock -> hardware: `docs/DRONES_MOCK_TO_HARDWARE_RUNBOOK.md`
 
+Ativação dos serviços de drones no ambiente local:
+```bash
+cd src
+docker compose --profile drones up -d ugv uav
+```
+
 Metas operacionais (SLO/SLA): `docs/SLOS_SLAS_CRITICAL_SERVICES.md`
 
 Resumo operacional:


### PR DESCRIPTION
## Resumo
- valida em teste de contrato que `src/docker-compose.yml` mantém serviços `ugv` e `uav` com `profiles: ["drones"]`
- atualiza wiki operacional com comando padrão para ativar profile de drones no ambiente local

## Testes
- .venv/bin/pytest -q tests/backend/test_drones_compose_profile_contract.py tests/backend

Closes #608
