### PR TITLE
docs: consolidar README raiz com contrato de qualidade

### DIFF
--- a/tests/backend/test_root_readme_contract.py
+++ b/tests/backend/test_root_readme_contract.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+README = ROOT / "README.md"
+
+
+def test_root_readme_exists_and_has_core_operational_sections():
+    content = README.read_text(encoding="utf-8")
+
+    assert content.startswith("# Home Security DIY")
+    assert "## Como começar" in content
+    assert "## Estrutura do repositório" in content
+    assert "## Contribuição" in content
+    assert "## Licença e Aviso Legal" in content

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -60,6 +60,7 @@ O projeto combina automação, vídeo inteligente, sensores e drones para segura
 - Estratégia de secrets no Kubernetes com External Secrets em produção (`k8s/overlays/production/external-secrets.yaml`).
 - Dependências dos drones totalmente pinadas (`==`), incluindo dependências opcionais comentadas para ativação futura.
 - Dependabot padronizado para `github-actions`, Docker, pip e npm com agenda semanal e labels de triagem.
+- README da raiz consolidado com setup de desenvolvimento/produção e fluxo operacional do dashboard.
 
 ## Documentação no repositório
 


### PR DESCRIPTION
## Resumo
- adiciona teste de contrato para garantir presença do README na raiz com seções operacionais mínimas
- atualiza wiki principal registrando README consolidado como fonte de setup/execução

## Testes
- .venv/bin/pytest -q tests/backend/test_root_readme_contract.py tests/backend

Closes #607
