### PR TITLE
test(mqtt): consolidar TLS 8883 no docker-compose

### DIFF
--- a/tests/backend/test_mqtt_tls_production_contract.py
+++ b/tests/backend/test_mqtt_tls_production_contract.py
@@ -5,6 +5,7 @@ ROOT = Path(__file__).resolve().parents[2]
 PROD_CONF = ROOT / "src" / "mosquitto" / "config" / "mosquitto.prod.conf"
 AUDIT_SCRIPT = ROOT / "scripts" / "network_security_audit.sh"
 CHECKLIST = ROOT / "docs" / "NETWORK_SECURITY_VLAN_CREDENTIALS_CHECKLIST.md"
+COMPOSE = ROOT / "src" / "docker-compose.yml"
 
 
 def test_mosquitto_production_profile_is_tls_only():
@@ -29,3 +30,12 @@ def test_network_checklist_mentions_tls_only_profile():
     content = CHECKLIST.read_text(encoding="utf-8")
 
     assert "Perfil de produção TLS-only versionado" in content
+
+
+def test_compose_selects_tls_only_mosquitto_profile_in_production():
+    content = COMPOSE.read_text(encoding="utf-8")
+
+    assert "mosquitto.prod.conf" in content
+    assert "APP_ENV:-development" in content
+    assert "production" in content
+    assert '"127.0.0.1:8883:8883"' in content

--- a/wiki/Operacao-e-Manutencao.md
+++ b/wiki/Operacao-e-Manutencao.md
@@ -104,6 +104,10 @@ Resumo operacional:
 - Alerta preventivo quando o consumo do error budget atingir 50% no mês.
 - Revisão formal das metas a cada semestre ou após recorrência de P1.
 
+MQTT TLS (produção):
+- Com `APP_ENV=production`, o Mosquitto usa `mosquitto.prod.conf` (TLS-only em `8883`).
+- Gerar certificados com `./scripts/generate-mqtt-certs.sh` antes da promoção.
+
 ## Hardening e resiliência
 
 - Consulte `docs/HARDENING_ANTI_TAMPER.md` para configurações de segurança


### PR DESCRIPTION
## Resumo
- reforça contrato de TLS MQTT validando compose com seleção de `mosquitto.prod.conf` em produção
- mantém validação da exposição da porta `127.0.0.1:8883` no compose
- atualiza wiki operacional com nota de execução TLS e geração de certificados

## Testes
- .venv/bin/pytest -q tests/backend/test_mqtt_tls_production_contract.py tests/backend

Closes #606
