### PR TITLE
test(frigate): consolidar restrição de portas em loopback

### DIFF
--- a/docs/NETWORK_SECURITY_VLAN_CREDENTIALS_CHECKLIST.md
+++ b/docs/NETWORK_SECURITY_VLAN_CREDENTIALS_CHECKLIST.md
@@ -20,7 +20,7 @@ Evidência técnica esperada: export de regras do firewall/switch.
 - [ ] SSID IoT com política segregada.
 - [ ] Firewall com regras restritivas aplicadas.
 - [ ] VPN WireGuard/Tailscale funcional para acesso remoto.
-- [x] Frigate (8554/8555) restrito a loopback no host.
+- [x] Frigate (5000/8554/8555) restrito a loopback no host.
   Evidência: `src/docker-compose.yml`
 
 ## 3. MQTT/TLS

--- a/tests/backend/test_frigate_port_exposure_contract.py
+++ b/tests/backend/test_frigate_port_exposure_contract.py
@@ -9,9 +9,11 @@ CHECKLIST = ROOT / "docs" / "NETWORK_SECURITY_VLAN_CREDENTIALS_CHECKLIST.md"
 def test_frigate_ports_are_loopback_only():
     content = COMPOSE.read_text(encoding="utf-8")
 
+    assert "127.0.0.1:5000:5000" in content
     assert "127.0.0.1:8554:8554" in content
     assert "127.0.0.1:8555:8555" in content
     assert "127.0.0.1:8555:8555/udp" in content
+    assert '- "5000:5000"' not in content
     assert "- \"8554:8554\"" not in content
     assert "- \"8555:8555\"" not in content
 
@@ -19,4 +21,4 @@ def test_frigate_ports_are_loopback_only():
 def test_network_checklist_mentions_frigate_loopback_binding():
     content = CHECKLIST.read_text(encoding="utf-8")
 
-    assert "Frigate (8554/8555) restrito a loopback" in content
+    assert "Frigate (5000/8554/8555) restrito a loopback" in content


### PR DESCRIPTION
## Resumo
- reforça contrato de segurança do Frigate validando bind em loopback para portas `5000`, `8554` e `8555`
- atualiza checklist de segurança de rede com referência explícita às três portas

## Testes
- .venv/bin/pytest -q tests/backend/test_frigate_port_exposure_contract.py tests/backend

Closes #605
