### PR TITLE
test(compose): restringir Dashboard API a loopback

### DIFF
--- a/docs/NETWORK_SECURITY_VLAN_CREDENTIALS_CHECKLIST.md
+++ b/docs/NETWORK_SECURITY_VLAN_CREDENTIALS_CHECKLIST.md
@@ -21,6 +21,7 @@ Evidência técnica esperada: export de regras do firewall/switch.
 - [ ] Firewall com regras restritivas aplicadas.
 - [ ] VPN WireGuard/Tailscale funcional para acesso remoto.
 - [x] Frigate (5000/8554/8555) restrito a loopback no host.
+- [x] Dashboard API (`8000`) restrita a loopback (`127.0.0.1`) no host.
   Evidência: `src/docker-compose.yml`
 
 ## 3. MQTT/TLS

--- a/tests/backend/test_compose_security_contract.py
+++ b/tests/backend/test_compose_security_contract.py
@@ -10,6 +10,7 @@ def test_dashboard_api_is_loopback_only_in_compose():
 
     assert '"127.0.0.1:8000:8000"' in content
     assert '"8000:8000"' not in content
+    assert '"0.0.0.0:8000:8000"' not in content
 
 
 def test_mqtt_tls_listener_is_exposed_in_loopback():

--- a/wiki/Operacao-e-Manutencao.md
+++ b/wiki/Operacao-e-Manutencao.md
@@ -128,6 +128,9 @@ docker compose logs -f homeassistant
 curl http://localhost:8000/api/services/status
 ```
 
+Nota de segurança:
+- No ambiente Docker Compose, a Dashboard API deve permanecer vinculada a `127.0.0.1:8000`.
+
 ## Perfil de validação em K3s (toca.lan)
 
 Hosts de acesso via ingress:


### PR DESCRIPTION
## Resumo
- reforça teste de contrato para impedir exposição da Dashboard API em `0.0.0.0:8000`
- atualiza checklist de segurança de rede com requisito explícito de loopback para a API
- adiciona nota operacional na wiki para manter bind em `127.0.0.1:8000` no Compose

## Testes
- .venv/bin/pytest -q tests/backend/test_compose_security_contract.py tests/backend

Closes #604
