### PR TITLE
test(compose): garantir healthchecks em todos os serviços

### DIFF
--- a/tests/backend/test_compose_security_contract.py
+++ b/tests/backend/test_compose_security_contract.py
@@ -30,8 +30,10 @@ def test_compose_has_healthchecks_for_critical_services():
         "homeassistant:",
         "dashboard-api:",
         "dashboard-frontend:",
+        "ugv:",
+        "uav:",
     ):
         assert service_name in content
 
-    # Contract-level check: critical services now define healthcheck in compose.
-    assert content.count("healthcheck:") >= 7
+    # Contract-level check: core + drones services define healthcheck in compose.
+    assert content.count("healthcheck:") >= 9

--- a/wiki/Operacao-e-Manutencao.md
+++ b/wiki/Operacao-e-Manutencao.md
@@ -27,6 +27,7 @@ O dashboard atualiza em tempo real via WebSocket (fan-out do Home Assistant).
 - [ ] Revisar alertas recentes no widget **AlertFeed**
 - [ ] Confirmar câmeras com snapshot atualizado no widget **CameraGrid**
 - [ ] Checar estado do alarme (Alarmo) no widget **AlarmStatus**
+- [ ] Confirmar healthchecks Docker ativos para serviços críticos e drones (`postgres`, `mosquitto`, `zigbee2mqtt`, `frigate`, `homeassistant`, `dashboard-api`, `dashboard-frontend`, `ugv`, `uav`)
 
 ## Backup e recuperação
 


### PR DESCRIPTION
## Resumo
- reforça contrato de compose para exigir healthchecks em serviços críticos e serviços de drones
- aumenta baseline de verificação para 9 healthchecks no compose
- atualiza checklist operacional da wiki com validação diária dos healthchecks

## Testes
- .venv/bin/pytest -q tests/backend/test_compose_security_contract.py tests/backend

Closes #603
