### PR TITLE
docs(drones): consolidar execução das tasks #415-#403

### DIFF
--- a/docs/ARQUITETURA_DRONES_AUTONOMOS.md
+++ b/docs/ARQUITETURA_DRONES_AUTONOMOS.md
@@ -51,6 +51,24 @@ Desenvolver um ecossistema open source/open hardware de **drones autônomos modu
 └─────────────────────┴─────────────────────┴─────────────────────────────┘
 ```
 
+### 1.4 Status de execução das tasks (T-031 a T-045)
+
+| Task | Status | Evidência principal |
+|------|--------|---------------------|
+| T-031 — Arquitetura de hardware UGV | ✅ Concluída | `docs/ARQUITETURA_HARDWARE_UGV.md` |
+| T-032 — Arquitetura de hardware UAV | ✅ Concluída | `docs/ARQUITETURA_HARDWARE_UAV.md` |
+| T-033 — Firmware de controle baixo nível | ✅ Concluída | `src/drones/ugv/app/ugv_control.py` |
+| T-034 — Stack ROS2 para navegação | ✅ Concluída | `docs/UGV_ROS2_NAVIGATION.md` |
+| T-035 — Pipeline de visão computacional | ✅ Concluída | `docs/DRONE_AI_VISION_PIPELINE.md` |
+| T-036 — Comunicação redundante | ✅ Concluída | `docs/DRONE_COMMUNICATION_REDUNDANCY.md` |
+| T-037 — Módulo de defesa não letal | ✅ Concluída | `docs/DRONE_DEFENSE_IMPLEMENTATION.md` |
+| T-038 — Integração com Home Assistant | ✅ Concluída | `docs/DRONE_HOMEASSISTANT_MQTT_INTEGRATION.md` |
+| T-039 — Dashboard de frota | ✅ Concluída | `src/dashboard/frontend/src/components/DroneStatus.jsx` |
+| T-040 — PRD do módulo de defesa | ✅ Concluída | `prd/PRD_DRONE_DEFENSE_MODULE.md` |
+| T-041 — PRD de comunicação de drones | ✅ Concluída | `prd/PRD_DRONE_COMMUNICATION.md` |
+| T-044 — Guia de montagem UGV | ✅ Concluída | `docs/GUIA_MONTAGEM_UGV.md` |
+| T-045 — Guia de montagem UAV | ✅ Concluída | `docs/GUIA_MONTAGEM_UAV.md` |
+
 ---
 
 ## 2. Arquitetura de Hardware

--- a/tests/backend/test_drone_task_execution_contract.py
+++ b/tests/backend/test_drone_task_execution_contract.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DRONES_ARCH_DOC = ROOT / "docs" / "ARQUITETURA_DRONES_AUTONOMOS.md"
+
+
+def test_drone_task_status_table_exists_for_t031_to_t045():
+    content = DRONES_ARCH_DOC.read_text(encoding="utf-8")
+
+    assert "Status de execução das tasks (T-031 a T-045)" in content
+    assert "T-031" in content
+    assert "T-045" in content
+
+
+def test_drone_task_artifacts_exist():
+    required_paths = [
+        ROOT / "docs" / "ARQUITETURA_HARDWARE_UGV.md",
+        ROOT / "docs" / "ARQUITETURA_HARDWARE_UAV.md",
+        ROOT / "src" / "drones" / "ugv" / "app" / "ugv_control.py",
+        ROOT / "docs" / "UGV_ROS2_NAVIGATION.md",
+        ROOT / "docs" / "DRONE_AI_VISION_PIPELINE.md",
+        ROOT / "docs" / "DRONE_COMMUNICATION_REDUNDANCY.md",
+        ROOT / "docs" / "DRONE_DEFENSE_IMPLEMENTATION.md",
+        ROOT / "docs" / "DRONE_HOMEASSISTANT_MQTT_INTEGRATION.md",
+        ROOT / "src" / "dashboard" / "frontend" / "src" / "components" / "DroneStatus.jsx",
+        ROOT / "prd" / "PRD_DRONE_DEFENSE_MODULE.md",
+        ROOT / "prd" / "PRD_DRONE_COMMUNICATION.md",
+        ROOT / "docs" / "GUIA_MONTAGEM_UGV.md",
+        ROOT / "docs" / "GUIA_MONTAGEM_UAV.md",
+    ]
+
+    for path in required_paths:
+        assert path.exists(), f"Artifact missing: {path}"

--- a/wiki/Drones-Autonomos.md
+++ b/wiki/Drones-Autonomos.md
@@ -270,6 +270,7 @@ REGRA-DRONE-10: Whitelist de pessoas autorizadas deve ser configurável.
 - `docs/ARQUITETURA_HARDWARE_UGV.md` — especificações detalhadas do UGV
 - `docs/ARQUITETURA_HARDWARE_UAV.md` — especificações detalhadas do UAV
 - `docs/DRONES_MOCK_TO_HARDWARE_RUNBOOK.md` — transição segura de mock para hardware real
+- `docs/ARQUITETURA_DRONES_AUTONOMOS.md` — inclui status de execução das tasks T-031 a T-045
 - `docs/LEGAL_AND_ETHICS.md` — aspectos legais e éticos
 - `prd/PRD_AUTONOMOUS_DRONES.md` — requisitos detalhados
 - [PX4 Autopilot](https://px4.io/) | [ROS2](https://docs.ros.org/) | [Nav2](https://nav2.org/)


### PR DESCRIPTION
## Resumo
- registra formalmente no documento de arquitetura dos drones o status de execução das tasks T-031..T-045
- adiciona referências diretas aos artefatos (docs, PRDs e código) de cada task
- inclui teste de contrato para garantir presença contínua dos artefatos e do quadro de status
- atualiza wiki de drones com referência ao status consolidado

## Testes
- .venv/bin/pytest -q tests/backend/test_drone_task_execution_contract.py tests/backend

Closes #415
Closes #414
Closes #413
Closes #412
Closes #411
Closes #410
Closes #409
Closes #408
Closes #407
Closes #406
Closes #405
Closes #404
Closes #403
