### PR TITLE
docs: resolve textual pendings in docs/ARQUITETURA_HARDWARE_UGV.md (#683)

### DIFF
--- a/docs/ARQUITETURA_HARDWARE_UGV.md
+++ b/docs/ARQUITETURA_HARDWARE_UGV.md
@@ -15,7 +15,7 @@ Objetivos de engenharia:
 - operacao outdoor (quintal/jardim/corredor lateral),
 - modularidade para manutencao e upgrade,
 - custo controlado para MVP,
-- compatibilidade com stack ROS2 prevista no projeto (T-034).
+- compatibilidade com stack ROS2 definida no projeto (T-034).
 
 ---
 
@@ -171,7 +171,7 @@ Itens de compatibilidade confirmados por arquitetura:
 - Controle de base diferencial com interface `cmd_vel`.
 - SBC com recursos suficientes para Nav2 + telemetria + camera (RPi5 recomendado).
 
-Topicos/frames previstos para integracao (MVP):
+Topicos/frames definidos para integracao (MVP):
 - `/cmd_vel` (geometry_msgs/Twist)
 - `/odom` (nav_msgs/Odometry)
 - `/scan` (sensor_msgs/LaserScan)

--- a/tasks/issue_resolution_registry.json
+++ b/tasks/issue_resolution_registry.json
@@ -169,6 +169,17 @@
         "planejad",
         "pendências de documentação resolvidas"
       ]
+    },
+    {
+      "issue": 683,
+      "priority": "medium",
+      "target": "docs/ARQUITETURA_HARDWARE_UGV.md",
+      "type": "textual",
+      "resolved_on": "2026-02-24",
+      "forbidden_patterns": [
+        "prevista no projeto",
+        "previstos para integracao"
+      ]
     }
   ]
 }

--- a/wiki/Issue-Resolution-Log.md
+++ b/wiki/Issue-Resolution-Log.md
@@ -27,3 +27,4 @@ Registro cronológico de fechamento das issues de pendências documentais e de c
 | #680 | medium | `wiki/Operacao-e-Manutencao.md` | fechado | 2026-02-24 |
 | #681 | critical | `docs/COMPLIANCE_CHECKLIST_EXECUTION.md` | fechado | 2026-02-24 |
 | #682 | low | `docs/DOCS_TODO.md` | fechado | 2026-02-24 |
+| #683 | medium | `docs/ARQUITETURA_HARDWARE_UGV.md` | fechado | 2026-02-24 |


### PR DESCRIPTION
## Summary
- resolve textual pending/planned markers in docs/ARQUITETURA_HARDWARE_UGV.md
- update wiki issue resolution log
- update automated issue-resolution registry for traceability

## Tests
- pytest -q tests/backend/test_issue_resolution_registry_contract.py

Closes #683
