### PR TITLE
fix: remover segredos hardcoded do dashboard e adicionar gate de CI (#715)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,6 +15,17 @@ on:
     branches: [main]
 
 jobs:
+  secret-hygiene:
+    name: Secret Hygiene Gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Block hardcoded secrets/placeholders in changed YAML/CONF
+        run: bash scripts/check-hardcoded-secrets.sh
+
   lint-yaml:
     name: Lint YAML
     runs-on: ubuntu-latest

--- a/k8s/base/dashboard/dashboard.yaml
+++ b/k8s/base/dashboard/dashboard.yaml
@@ -14,15 +14,7 @@ metadata:
     app.kubernetes.io/name: dashboard
     app.kubernetes.io/component: credentials
 type: Opaque
-  # IMPORTANT: Never commit real values here.
-  # Use scripts/generate-k8s-secrets.sh or SealedSecrets/ESO for real deployments.
-stringData:
-  ha-token: "CHANGE_ME_ha_long_lived_token"
-  ha-url: "http://HOME_ASSISTANT_HOST_IP:8123"
-  database-url: "postgresql+asyncpg://dashboard_user:CHANGE_ME_dashboard_password@postgres:5432/homedb?options=-csearch_path%3Ddashboard"
-  dashboard-api-key: "CHANGE_ME_generate_with_openssl_rand_hex_32"
-  dashboard-admin-key: "CHANGE_ME_generate_with_openssl_rand_hex_32"
-  dashboard-allowed-origins: "https://dashboard.home.local"
+stringData: {}
 
 ---
 # --- ConfigMap: variáveis não-sensíveis ---
@@ -75,11 +67,20 @@ spec:
               name: http
           env:
             - name: HA_URL
-              value: "http://homeassistant:8123"
+              valueFrom:
+                secretKeyRef:
+                  name: dashboard-credentials
+                  key: ha-url
             - name: HA_TOKEN
-              value: "ha_token_validation_2026_secure"
+              valueFrom:
+                secretKeyRef:
+                  name: dashboard-credentials
+                  key: ha-token
             - name: DATABASE_URL
-              value: "postgresql+asyncpg://dashboard_user:HomeSec-PG-2026!@postgres:5432/homedb"
+              valueFrom:
+                secretKeyRef:
+                  name: dashboard-credentials
+                  key: database-url
             - name: FRIGATE_URL
               valueFrom:
                 configMapKeyRef:
@@ -91,18 +92,29 @@ spec:
                   name: dashboard-config
                   key: MQTT_BROKER
             - name: DASHBOARD_API_KEY
-              value: "HomeSec-Dashboard-ApiKey-2026"
+              valueFrom:
+                secretKeyRef:
+                  name: dashboard-credentials
+                  key: dashboard-api-key
             - name: DASHBOARD_ADMIN_KEY
-              value: "HomeSec-Dashboard-AdminKey-2026"
+              valueFrom:
+                secretKeyRef:
+                  name: dashboard-credentials
+                  key: dashboard-admin-key
             - name: DASHBOARD_ALLOWED_ORIGINS
-              value: '["https://dashboard-home-security.toca.lan"]'
+              valueFrom:
+                secretKeyRef:
+                  name: dashboard-credentials
+                  key: dashboard-allowed-origins
             - name: TZ
               valueFrom:
                 configMapKeyRef:
                   name: dashboard-config
                   key: TZ
           securityContext:
-            runAsNonRoot: false
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:

--- a/scripts/check-hardcoded-secrets.sh
+++ b/scripts/check-hardcoded-secrets.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${1:-}"
+
+if [[ -z "${BASE_REF}" ]]; then
+  if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+    BASE_REF="origin/${GITHUB_BASE_REF}"
+  elif git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+    BASE_REF="HEAD~1"
+  else
+    BASE_REF="HEAD"
+  fi
+fi
+
+changed_files="$(git diff --name-only --diff-filter=ACMRT "${BASE_REF}"...HEAD || true)"
+target_files="$(echo "${changed_files}" | grep -E '\.(ya?ml|conf|template)$' || true)"
+
+if [[ -z "${target_files}" ]]; then
+  echo "No changed YAML/CONF/template files to scan."
+  exit 0
+fi
+
+echo "Scanning changed files for hardcoded secrets..."
+echo "${target_files}" | sed 's/^/ - /'
+
+failed=0
+while IFS= read -r file; do
+  [[ -z "${file}" ]] && continue
+  [[ -f "${file}" ]] || continue
+
+  if grep -nE 'CHANGE_ME|HomeSec-[A-Za-z0-9._-]+' "${file}" >/dev/null; then
+    echo "[FAIL] Placeholder or inline credential marker in ${file}:"
+    grep -nE 'CHANGE_ME|HomeSec-[A-Za-z0-9._-]+' "${file}" || true
+    failed=1
+  fi
+
+  if grep -nE 'proxy_set_header[[:space:]]+X-(API|Admin)-Key[[:space:]]+"[^"$]+' "${file}" >/dev/null; then
+    echo "[FAIL] Hardcoded API/Admin key header in ${file}:"
+    grep -nE 'proxy_set_header[[:space:]]+X-(API|Admin)-Key[[:space:]]+"[^"$]+' "${file}" || true
+    failed=1
+  fi
+
+  if [[ "${file}" == *.yml || "${file}" == *.yaml ]]; then
+    if awk '
+      BEGIN { sensitive = ""; bad = 0 }
+      /^[[:space:]]*-[[:space:]]*name:[[:space:]]*(HA_TOKEN|DATABASE_URL|DASHBOARD_API_KEY|DASHBOARD_ADMIN_KEY)[[:space:]]*$/ {
+        sensitive = $0
+        next
+      }
+      sensitive != "" && /^[[:space:]]*value:[[:space:]]*/ {
+        print "[FAIL] Sensitive env uses value instead of valueFrom in '"${file}"': " $0
+        bad = 1
+        sensitive = ""
+        next
+      }
+      sensitive != "" && /^[[:space:]]*valueFrom:[[:space:]]*$/ {
+        sensitive = ""
+        next
+      }
+      sensitive != "" && /^[[:space:]]*$/ { next }
+      sensitive != "" && /^[[:space:]]*#/ { next }
+      sensitive != "" { sensitive = "" }
+      END { exit bad }
+    ' "${file}"; then
+      :
+    else
+      failed=1
+    fi
+  fi
+done <<< "${target_files}"
+
+if [[ "${failed}" -ne 0 ]]; then
+  echo "Hardcoded secret scan failed."
+  exit 1
+fi
+
+echo "Hardcoded secret scan passed."

--- a/src/dashboard/frontend/nginx.conf.template
+++ b/src/dashboard/frontend/nginx.conf.template
@@ -23,9 +23,8 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        # Injeta API key de nível operator para chamadas do frontend.
-        proxy_set_header X-API-Key "HomeSec-Dashboard-ApiKey-2026";
-        # X-Admin-Key é passado pelo cliente explicitamente para operações admin
+        # Nenhuma credencial estática é injetada no proxy.
+        # O cliente deve enviar sessão/token de autenticação válido.
     }
 
     # Proxy WebSocket

--- a/wiki/Issue-Resolution-Log.md
+++ b/wiki/Issue-Resolution-Log.md
@@ -31,3 +31,4 @@ Registro cronológico de fechamento das issues de pendências documentais e de c
 | #684 | critical | `docs/LEGALIDADE_MODULO_DEFESA_SP_RJ_MG.md` | fechado | 2026-02-24 |
 | #685 | medium | `prd/PRD_DRONE_DEFENSE_MODULE.md` | fechado | 2026-02-24 |
 | #686 | low | `rules/RULES_GENERAL.md` | fechado | 2026-02-24 |
+| #715 | high | `k8s/base/dashboard/dashboard.yaml`, `src/dashboard/frontend/nginx.conf.template`, `scripts/check-hardcoded-secrets.sh` | fechado | 2026-03-02 |

--- a/wiki/Seguranca-e-Compliance.md
+++ b/wiki/Seguranca-e-Compliance.md
@@ -113,6 +113,13 @@ BACKUP_ENCRYPTION_PASSPHRASE=<senha forte>
 
 > **Atenção:** O sistema recusa inicialização se qualquer um desses valores estiver ausente ou contiver `CHANGE_ME`/`UNCONFIGURED`.
 
+## Gestão de segredos no Dashboard (Issue #715)
+
+- `k8s/base/dashboard/dashboard.yaml` não versiona mais valores sensíveis em texto claro.
+- A API do dashboard passa a consumir `HA_TOKEN`, `DATABASE_URL`, `DASHBOARD_API_KEY` e `DASHBOARD_ADMIN_KEY` exclusivamente por `secretKeyRef`.
+- O proxy frontend (`nginx.conf.template`) não injeta mais `X-API-Key` estático.
+- O pipeline de validação executa `scripts/check-hardcoded-secrets.sh` para bloquear placeholders e credenciais hardcoded em arquivos YAML/CONF alterados.
+
 ---
 
 ## Hardening do Servidor


### PR DESCRIPTION
## Resumo
Resolve a issue #715 removendo segredos/chaves hardcoded do dashboard e adicionando um gate de CI para bloquear recorrência em YAML/CONF.

## Mudanças
- remove X-API-Key estático no proxy Nginx do frontend
- converte variáveis sensíveis da API para valueFrom.secretKeyRef
- remove valores versionados do Secret base (stringData vazio)
- adiciona scanner scripts/check-hardcoded-secrets.sh
- adiciona job Secret Hygiene Gate em .github/workflows/validate.yml
- atualiza wiki de segurança e log de resolução

## Validação
- bash -n scripts/check-hardcoded-secrets.sh

Closes #715
