### PR TITLE
feat: autenticação browser para WS/REST e paridade dev/prod (#716 #717)

### DIFF
--- a/src/dashboard/backend/app/security.py
+++ b/src/dashboard/backend/app/security.py
@@ -135,6 +135,10 @@ async def require_ws_api_key(websocket: WebSocket) -> None:
     auth = websocket.headers.get("authorization", "")
     if not token and auth.lower().startswith("bearer "):
         token = auth.split(" ", 1)[1].strip()
+    if not token:
+        token = websocket.query_params.get("token")
+    if not token:
+        token = websocket.query_params.get("api_key")
 
     if _is_valid_api_key(token, expected):
         return

--- a/src/dashboard/frontend/eslint.config.js
+++ b/src/dashboard/frontend/eslint.config.js
@@ -15,6 +15,8 @@ export default [
         fetch: "readonly",
         WebSocket: "readonly",
         URLSearchParams: "readonly",
+        localStorage: "readonly",
+        sessionStorage: "readonly",
         FileReader: "readonly",
         setInterval: "readonly",
         clearInterval: "readonly",

--- a/src/dashboard/frontend/src/components/AlertFeed.jsx
+++ b/src/dashboard/frontend/src/components/AlertFeed.jsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import useStore from '../store/useStore'
+import { apiFetch } from '../utils/auth'
 
 const SEVERITY_STYLE = {
   critical: 'border-l-critical text-red-300',
@@ -25,7 +26,7 @@ export default function AlertFeed() {
 
   // Carrega histórico inicial via REST
   useEffect(() => {
-    fetch('/api/alerts?limit=30')
+    apiFetch('/api/alerts?limit=30')
       .then((r) => r.json())
       .then((data) => { if (Array.isArray(data)) setAlertsIfEmpty(data) })
       .catch(() => {})

--- a/src/dashboard/frontend/src/components/OperationalMap.jsx
+++ b/src/dashboard/frontend/src/components/OperationalMap.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import useStore from '../store/useStore'
+import { apiFetch } from '../utils/auth'
 
 const DEFAULT_DEVICES = [
   { entity_id: 'camera.cam_entrada', label: 'Câm Entrada', x: 50, y: 5, device_type: 'camera' },
@@ -78,12 +79,12 @@ export default function OperationalMap() {
   const [flash, setFlash] = useState('')
 
   useEffect(() => {
-    fetch('/api/map/devices')
+    apiFetch('/api/map/devices')
       .then((r) => r.json())
       .then((data) => { if (Array.isArray(data) && data.length > 0) setDevices(data) })
       .catch(() => {})
 
-    fetch('/api/map/config')
+    apiFetch('/api/map/config')
       .then((r) => r.json())
       .then((cfg) => {
         setMapConfig({
@@ -144,7 +145,7 @@ export default function OperationalMap() {
   }, [uavPosition?.x, uavPosition?.y])
 
   async function saveMapConfig(nextConfig) {
-    const resp = await fetch('/api/map/config', {
+    const resp = await apiFetch('/api/map/config', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(nextConfig),
@@ -174,7 +175,7 @@ export default function OperationalMap() {
     setBusy(true)
     setFlash('')
     try {
-      const resp = await fetch('/api/drones/command', {
+      const resp = await apiFetch('/api/drones/command', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ drone, action }),

--- a/src/dashboard/frontend/src/components/ServiceStatus.jsx
+++ b/src/dashboard/frontend/src/components/ServiceStatus.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { apiFetch } from '../utils/auth'
 
 const SERVICE_LABELS = {
   home_assistant: 'Home Assistant',
@@ -12,7 +13,7 @@ export default function ServiceStatus() {
   useEffect(() => {
     async function fetch_status() {
       try {
-        const resp = await fetch('/api/services/status')
+        const resp = await apiFetch('/api/services/status')
         const data = await resp.json()
         setServices(data.services ?? {})
       } catch {

--- a/src/dashboard/frontend/src/hooks/useAssets.js
+++ b/src/dashboard/frontend/src/hooks/useAssets.js
@@ -4,6 +4,7 @@
  */
 import { useCallback, useEffect } from 'react'
 import useStore from '../store/useStore'
+import { apiFetch } from '../utils/auth'
 
 export function useAssets() {
   const { assets, assetsLoading, assetsError, setAssets, setAssetsLoading, setAssetsError } =
@@ -17,7 +18,7 @@ export function useAssets() {
       if (assetType) params.set('asset_type', assetType)
       if (isActive !== undefined) params.set('is_active', String(isActive))
 
-      const resp = await fetch(`/api/assets?${params}`)
+      const resp = await apiFetch(`/api/assets?${params}`)
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
       const data = await resp.json()
       setAssets(data.items ?? [])

--- a/src/dashboard/frontend/src/hooks/useAssets.test.jsx
+++ b/src/dashboard/frontend/src/hooks/useAssets.test.jsx
@@ -30,7 +30,10 @@ describe("useAssets hook", () => {
       expect(result.current.assets).toHaveLength(2);
     });
 
-    expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining("/api/assets"));
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/assets"),
+      expect.any(Object),
+    );
     expect(result.current.assetsError).toBeNull();
     expect(result.current.assetsLoading).toBe(false);
   });

--- a/src/dashboard/frontend/src/hooks/useWebSocket.js
+++ b/src/dashboard/frontend/src/hooks/useWebSocket.js
@@ -1,15 +1,6 @@
 import { useEffect, useRef } from 'react'
 import useStore from '../store/useStore'
-
-function buildWsUrl() {
-  if (typeof window === 'undefined') {
-    return 'ws://localhost:8000/ws'
-  }
-  const wsScheme = window.location.protocol === 'https:' ? 'wss' : 'ws'
-  return `${wsScheme}://${window.location.host}/ws`
-}
-
-const WS_URL = buildWsUrl()
+import { buildWsUrl } from '../utils/auth'
 
 export function useWebSocket() {
   const wsRef = useRef(null)
@@ -21,7 +12,7 @@ export function useWebSocket() {
 
     function connect() {
       setWsStatus('connecting')
-      const ws = new WebSocket(WS_URL)
+      const ws = new WebSocket(buildWsUrl())
       wsRef.current = ws
 
       ws.onopen = () => {

--- a/src/dashboard/frontend/src/hooks/useWebSocket.test.jsx
+++ b/src/dashboard/frontend/src/hooks/useWebSocket.test.jsx
@@ -45,13 +45,17 @@ describe("useWebSocket", () => {
     updateState.mockClear();
     addAlert.mockClear();
     setWsStatus.mockClear();
+    window.sessionStorage.clear();
+    window.localStorage.clear();
     global.WebSocket = MockWebSocket;
   });
 
   it("opens socket and updates ws status", async () => {
+    window.sessionStorage.setItem("dashboard_api_key", "browser-token");
     render(<TestComponent />);
     await Promise.resolve();
     expect(MockWebSocket.instances.length).toBe(1);
+    expect(MockWebSocket.instances[0].url).toContain("/ws?token=browser-token");
     expect(setWsStatus).toHaveBeenCalledWith("connecting");
     expect(setWsStatus).toHaveBeenCalledWith("connected");
   });

--- a/src/dashboard/frontend/src/pages/AssetsAdmin.jsx
+++ b/src/dashboard/frontend/src/pages/AssetsAdmin.jsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import useStore from '../store/useStore'
 import { useAssets } from '../hooks/useAssets'
+import { apiFetch } from '../utils/auth'
 
 const ASSET_TYPE_LABELS = {
   sensor: 'Sensor',
@@ -80,7 +81,7 @@ function AssetForm({ initial, onSave, onCancel, adminKey }) {
 
       const url = isEdit ? `/api/assets/${initial.id}` : '/api/assets'
       const method = isEdit ? 'PUT' : 'POST'
-      const resp = await fetch(url, {
+      const resp = await apiFetch(url, {
         method,
         headers: {
           'Content-Type': 'application/json',
@@ -324,7 +325,7 @@ export default function AssetsAdmin() {
     if (!confirmed) return
 
     try {
-      const resp = await fetch(`/api/assets/${asset.id}`, {
+      const resp = await apiFetch(`/api/assets/${asset.id}`, {
         method: 'DELETE',
         headers: { 'X-Admin-Key': adminKey },
       })
@@ -339,7 +340,7 @@ export default function AssetsAdmin() {
   async function handleRestore(asset) {
     if (!adminKey) { showFeedback('Informe a chave de administrador.', true); return }
     try {
-      const resp = await fetch(`/api/assets/${asset.id}/restore`, {
+      const resp = await apiFetch(`/api/assets/${asset.id}/restore`, {
         method: 'POST',
         headers: { 'X-Admin-Key': adminKey },
       })

--- a/src/dashboard/frontend/src/utils/auth.js
+++ b/src/dashboard/frontend/src/utils/auth.js
@@ -1,0 +1,50 @@
+const TOKEN_STORAGE_KEY = "dashboard_api_key";
+
+function readTokenFromStorage() {
+  if (typeof window === "undefined") return null;
+  return (
+    window.sessionStorage.getItem(TOKEN_STORAGE_KEY) ||
+    window.localStorage.getItem(TOKEN_STORAGE_KEY) ||
+    null
+  );
+}
+
+export function getApiToken() {
+  if (typeof window === "undefined") return null;
+
+  const fromStorage = readTokenFromStorage();
+  if (fromStorage) return fromStorage;
+
+  const params = new URLSearchParams(window.location.search);
+  const fromQuery = params.get("token") || params.get("api_key");
+  if (!fromQuery) return null;
+
+  window.sessionStorage.setItem(TOKEN_STORAGE_KEY, fromQuery);
+  return fromQuery;
+}
+
+export function withApiAuthHeaders(headers = {}) {
+  const token = getApiToken();
+  if (!token) return headers;
+  return {
+    ...headers,
+    Authorization: `Bearer ${token}`,
+  };
+}
+
+export async function apiFetch(input, init = {}) {
+  const mergedHeaders = withApiAuthHeaders(init.headers || {});
+  return fetch(input, { ...init, headers: mergedHeaders });
+}
+
+export function buildWsUrl() {
+  if (typeof window === "undefined") {
+    return "ws://localhost:8000/ws";
+  }
+  const wsScheme = window.location.protocol === "https:" ? "wss" : "ws";
+  const token = getApiToken();
+  const base = `${wsScheme}://${window.location.host}/ws`;
+  if (!token) return base;
+  const params = new URLSearchParams({ token });
+  return `${base}?${params.toString()}`;
+}

--- a/tests/backend/test_dashboard_auth_parity_contract.py
+++ b/tests/backend/test_dashboard_auth_parity_contract.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+NGINX_CONF = ROOT / "src" / "dashboard" / "frontend" / "nginx.conf.template"
+VITE_CONFIG = ROOT / "src" / "dashboard" / "frontend" / "vite.config.js"
+
+
+def test_prod_nginx_does_not_inject_static_api_key():
+    content = NGINX_CONF.read_text(encoding="utf-8")
+    assert "proxy_set_header X-API-Key" not in content
+    assert "proxy_set_header X-Admin-Key" not in content
+
+
+def test_dev_vite_proxy_does_not_inject_auth_headers():
+    content = VITE_CONFIG.read_text(encoding="utf-8")
+    assert "'/api'" in content
+    assert "'/ws'" in content
+    assert "headers:" not in content

--- a/tests/backend/test_ws_auth_contract.py
+++ b/tests/backend/test_ws_auth_contract.py
@@ -5,9 +5,8 @@ ROOT = Path(__file__).resolve().parents[2]
 SECURITY = ROOT / "src" / "dashboard" / "backend" / "app" / "security.py"
 
 
-def test_ws_auth_does_not_accept_query_params():
+def test_ws_auth_accepts_browser_query_token():
     content = SECURITY.read_text(encoding="utf-8")
 
     assert 'websocket.headers.get("x-api-key")' in content
-    assert "query_params.get(\"api_key\")" not in content
-    assert "query_params.get(\"token\")" not in content
+    assert 'query_params.get("token")' in content

--- a/tests/backend/test_ws_browser_auth.py
+++ b/tests/backend/test_ws_browser_auth.py
@@ -1,0 +1,20 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers import ws
+from app.services import ha_client
+
+
+def test_ws_allows_browser_token_query(monkeypatch):
+    app = FastAPI()
+    app.include_router(ws.router)
+
+    monkeypatch.setattr(ha_client, "subscribe", lambda _cb: None)
+    monkeypatch.setattr(ha_client, "unsubscribe", lambda _cb: None)
+    monkeypatch.setattr(ha_client, "get_ws_metrics", lambda: {"connected_clients": 0})
+    monkeypatch.setattr(ha_client, "get_all_states", lambda: {})
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/ws?token=test-api-key") as socket:
+            payload = socket.receive_json()
+            assert payload["type"] == "initial_state"

--- a/wiki/APIs-e-Integracao.md
+++ b/wiki/APIs-e-Integracao.md
@@ -35,6 +35,7 @@ O sistema expõe APIs REST, WebSocket e MQTT para comunicação entre componente
 | Mosquitto MQTT | TCP | 1883 | Usuário/senha |
 | Zigbee2MQTT REST | HTTP/JSON | 8080 | Nenhuma (VLAN) |
 | Dashboard API | HTTP/JSON | 8000 | `X-API-Key` ou Bearer |
+| Dashboard WebSocket | WebSocket | 8000 | Bearer/header ou `token` na query |
 
 ---
 
@@ -254,6 +255,12 @@ Usada pelo dashboard para atualizações em tempo real sem polling.
 **Autenticação obrigatória**:
 - `X-API-Key: <DASHBOARD_API_KEY>`
 - ou `Authorization: Bearer <DASHBOARD_API_KEY>`
+
+### WebSocket do Dashboard (`/ws`)
+
+- Browser sem suporte a header custom no handshake deve usar `wss://<host>/ws?token=<DASHBOARD_API_KEY>`.
+- Clientes não-browser podem usar `X-API-Key` ou `Authorization: Bearer`.
+- O endpoint envia `initial_state` imediatamente após autenticação e mantém stream de `state_changed`.
 
 | Método | Rota | Descrição |
 |--------|------|-----------|

--- a/wiki/Issue-Resolution-Log.md
+++ b/wiki/Issue-Resolution-Log.md
@@ -32,3 +32,5 @@ Registro cronológico de fechamento das issues de pendências documentais e de c
 | #685 | medium | `prd/PRD_DRONE_DEFENSE_MODULE.md` | fechado | 2026-02-24 |
 | #686 | low | `rules/RULES_GENERAL.md` | fechado | 2026-02-24 |
 | #715 | high | `k8s/base/dashboard/dashboard.yaml`, `src/dashboard/frontend/nginx.conf.template`, `scripts/check-hardcoded-secrets.sh` | fechado | 2026-03-02 |
+| #716 | high | `src/dashboard/backend/app/security.py`, `src/dashboard/frontend/src/hooks/useWebSocket.js`, `tests/backend/test_ws_browser_auth.py` | fechado | 2026-03-02 |
+| #717 | high | `src/dashboard/frontend/src/utils/auth.js`, `src/dashboard/frontend/src/hooks/useAssets.js`, `tests/backend/test_dashboard_auth_parity_contract.py` | fechado | 2026-03-02 |

--- a/wiki/Seguranca-e-Compliance.md
+++ b/wiki/Seguranca-e-Compliance.md
@@ -120,6 +120,18 @@ BACKUP_ENCRYPTION_PASSPHRASE=<senha forte>
 - O proxy frontend (`nginx.conf.template`) não injeta mais `X-API-Key` estático.
 - O pipeline de validação executa `scripts/check-hardcoded-secrets.sh` para bloquear placeholders e credenciais hardcoded em arquivos YAML/CONF alterados.
 
+## Autenticação WebSocket no browser (Issue #716)
+
+- O endpoint `/ws` aceita autenticação por query token (`?token=`) para navegadores que não conseguem enviar `X-API-Key` no handshake.
+- Fluxos não-browser continuam suportando `X-API-Key` e `Authorization: Bearer`.
+- Há teste automatizado cobrindo conexão autenticada com recebimento do evento inicial (`initial_state`).
+
+## Paridade de autenticação dev/prod (Issue #717)
+
+- Frontend passou a usar util único (`apiFetch` + token bearer) para chamadas REST e WebSocket.
+- O fluxo de autenticação agora é do cliente para backend em ambos os ambientes (Vite e Nginx), sem injeção de chave estática no proxy.
+- Teste de contrato valida que `vite.config.js` e `nginx.conf.template` não injetam headers de autenticação.
+
 ---
 
 ## Hardening do Servidor


### PR DESCRIPTION
## Resumo
Resolve as issues #716 e #717 unificando autenticação de browser para WebSocket e REST sem dependência de chave estática no proxy.

## Mudanças
- backend WS aceita token de autenticação via query param token para handshake de browser
- frontend centraliza auth em util único (apiFetch + buildWsUrl)
- chamadas REST do frontend passam a reutilizar token bearer do cliente
- adiciona teste de autenticação WS em browser com recebimento de initial_state
- adiciona teste de contrato de paridade dev/prod (sem injeção de headers em Vite/Nginx)
- atualiza wiki de integração, segurança e log de resolução de issues

## Validação local
- python3 -m py_compile src/dashboard/backend/app/security.py tests/backend/test_ws_auth_contract.py tests/backend/test_ws_browser_auth.py tests/backend/test_dashboard_auth_parity_contract.py
- não foi possível executar pytest/vitest completos neste ambiente por falta de dependências instaladas (fastapi/vitest)

Closes #716
Closes #717
