### PR TITLE
fix: auditoria de IP com trusted proxies (#718)

### DIFF
--- a/src/.env.example
+++ b/src/.env.example
@@ -68,6 +68,8 @@ HA_TOKEN=CHANGE_ME_ha_long_lived_token
 DASHBOARD_API_KEY=CHANGE_ME_dashboard_api_key
 # Origens permitidas no CORS (separadas por vírgula)
 DASHBOARD_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+# Proxies reversos confiáveis para aceitar X-Forwarded-For na trilha de auditoria
+TRUSTED_PROXY_IPS=127.0.0.1,172.17.0.1
 
 # --- Drones: Defesa ativa ---
 # Nunca versionar os PINs reais no repositório.

--- a/src/dashboard/backend/app/config.py
+++ b/src/dashboard/backend/app/config.py
@@ -23,6 +23,7 @@ class Settings(BaseSettings):
         "http://localhost:3000",
         "http://127.0.0.1:3000",
     ]
+    trusted_proxy_ips: list[str] = []
 
     # PostgreSQL (schema: dashboard)
     database_url: str = "postgresql+asyncpg://UNCONFIGURED:UNCONFIGURED@localhost/UNCONFIGURED"
@@ -54,6 +55,13 @@ class Settings(BaseSettings):
     def parse_origins(cls, value):
         if isinstance(value, str):
             return [origin.strip() for origin in value.split(",") if origin.strip()]
+        return value
+
+    @field_validator("trusted_proxy_ips", mode="before")
+    @classmethod
+    def parse_trusted_proxy_ips(cls, value):
+        if isinstance(value, str):
+            return [ip.strip() for ip in value.split(",") if ip.strip()]
         return value
 
     @field_validator("database_url")

--- a/src/dashboard/backend/app/db/models.py
+++ b/src/dashboard/backend/app/db/models.py
@@ -166,6 +166,7 @@ class AssetAudit(Base):
     after_json: Mapped[str | None] = mapped_column(Text)  # estado posterior (JSON)
     actor: Mapped[str | None] = mapped_column(String(100))  # usuário/sistema que executou
     actor_ip: Mapped[str | None] = mapped_column(String(45))  # IPv4 ou IPv6
+    actor_ip_chain: Mapped[str | None] = mapped_column(Text)  # cadeia X-Forwarded-For normalizada
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),

--- a/src/dashboard/backend/app/routers/assets.py
+++ b/src/dashboard/backend/app/routers/assets.py
@@ -3,6 +3,7 @@
 import json
 import uuid
 from datetime import datetime, timezone
+from ipaddress import ip_address
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
@@ -12,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models import Asset, AssetAudit, AssetCredential
 from app.db.session import get_db
+from app.config import settings
 from app.security import require_admin_key
 
 router = APIRouter(prefix="/api/assets", tags=["assets"])
@@ -99,11 +101,45 @@ def _get_actor(request: Request) -> str:
     return request.headers.get("X-Actor", "api")
 
 
-def _get_actor_ip(request: Request) -> str:
+def _normalize_ip(value: str | None) -> str | None:
+    if value is None:
+        return None
+    candidate = value.strip()
+    if not candidate:
+        return None
+    try:
+        return str(ip_address(candidate))
+    except ValueError:
+        return None
+
+
+def _trusted_proxies() -> set[str]:
+    return {ip for ip in (_normalize_ip(raw) for raw in settings.trusted_proxy_ips) if ip}
+
+
+def _forwarded_chain(request: Request) -> str | None:
     forwarded = request.headers.get("X-Forwarded-For")
-    if forwarded:
-        return forwarded.split(",")[0].strip()
-    return request.client.host if request.client else "unknown"
+    if not forwarded:
+        return None
+    ips = []
+    for raw_ip in forwarded.split(","):
+        normalized = _normalize_ip(raw_ip)
+        if normalized:
+            ips.append(normalized)
+    if not ips:
+        return None
+    return ",".join(ips)
+
+
+def _get_actor_ip(request: Request) -> str:
+    direct_ip = _normalize_ip(request.client.host if request.client else None) or "unknown"
+    chain = _forwarded_chain(request)
+    if not chain:
+        return direct_ip
+    if direct_ip not in _trusted_proxies():
+        return direct_ip
+    forwarded_ips = chain.split(",")
+    return forwarded_ips[0] if forwarded_ips else direct_ip
 
 
 async def _write_audit(
@@ -115,6 +151,7 @@ async def _write_audit(
     after: dict | None,
     actor: str,
     actor_ip: str,
+    actor_ip_chain: str | None,
 ) -> None:
     audit = AssetAudit(
         asset_id=asset_id,
@@ -123,6 +160,7 @@ async def _write_audit(
         after_json=json.dumps(after, default=str) if after else None,
         actor=actor,
         actor_ip=actor_ip,
+        actor_ip_chain=actor_ip_chain,
     )
     db.add(audit)
 
@@ -204,6 +242,7 @@ async def create_asset(
 
     actor = _get_actor(request)
     actor_ip = _get_actor_ip(request)
+    actor_ip_chain = _forwarded_chain(request)
     now = datetime.now(timezone.utc)
     asset = Asset(
         id=uuid.uuid4(),
@@ -231,6 +270,7 @@ async def create_asset(
         after=_asset_to_dict(asset),
         actor=actor,
         actor_ip=actor_ip,
+        actor_ip_chain=actor_ip_chain,
     )
     await db.commit()
     await db.refresh(asset)
@@ -257,6 +297,7 @@ async def update_asset(
     before = _asset_to_dict(asset)
     actor = _get_actor(request)
     actor_ip = _get_actor_ip(request)
+    actor_ip_chain = _forwarded_chain(request)
 
     if payload.name is not None:
         asset.name = payload.name
@@ -281,6 +322,7 @@ async def update_asset(
         after=_asset_to_dict(asset),
         actor=actor,
         actor_ip=actor_ip,
+        actor_ip_chain=actor_ip_chain,
     )
     await db.commit()
     await db.refresh(asset)
@@ -306,6 +348,7 @@ async def delete_asset(
     before = _asset_to_dict(asset)
     actor = _get_actor(request)
     actor_ip = _get_actor_ip(request)
+    actor_ip_chain = _forwarded_chain(request)
 
     asset.is_active = False
     asset.status = "inactive"
@@ -320,6 +363,7 @@ async def delete_asset(
         after=_asset_to_dict(asset),
         actor=actor,
         actor_ip=actor_ip,
+        actor_ip_chain=actor_ip_chain,
     )
     await db.commit()
     return {"status": "deactivated", "id": str(asset_id)}
@@ -344,6 +388,7 @@ async def restore_asset(
     before = _asset_to_dict(asset)
     actor = _get_actor(request)
     actor_ip = _get_actor_ip(request)
+    actor_ip_chain = _forwarded_chain(request)
 
     asset.is_active = True
     asset.status = "active"
@@ -358,6 +403,7 @@ async def restore_asset(
         after=_asset_to_dict(asset),
         actor=actor,
         actor_ip=actor_ip,
+        actor_ip_chain=actor_ip_chain,
     )
     await db.commit()
     await db.refresh(asset)

--- a/src/dashboard/backend/migrations/versions/20260302_0004_asset_audit_forwarded_chain.py
+++ b/src/dashboard/backend/migrations/versions/20260302_0004_asset_audit_forwarded_chain.py
@@ -1,0 +1,29 @@
+"""add actor_ip_chain to asset_audit
+
+Revision ID: 20260302_0004
+Revises: 20260223_0003
+Create Date: 2026-03-02 00:00:00
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260302_0004"
+down_revision: Union[str, None] = "20260223_0003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "asset_audit",
+        sa.Column("actor_ip_chain", sa.Text(), nullable=True),
+        schema="dashboard",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("asset_audit", "actor_ip_chain", schema="dashboard")

--- a/tests/backend/test_assets_router_coverage.py
+++ b/tests/backend/test_assets_router_coverage.py
@@ -9,10 +9,12 @@ import pytest
 from fastapi import HTTPException
 from pydantic import ValidationError
 
+from app.config import settings
 from app.db.models import Asset
 from app.routers.assets import (
     AssetCreate,
     AssetUpdate,
+    _forwarded_chain,
     _get_actor_ip,
     create_asset,
     delete_asset,
@@ -123,9 +125,29 @@ def test_asset_update_validator_rejects_invalid_json():
         AssetUpdate(config_json="{invalid-json")
 
 
-def test_get_actor_ip_prefers_x_forwarded_for():
-    req = _request(forwarded_for="192.168.1.10, 10.0.0.1")
-    assert _get_actor_ip(req) == "192.168.1.10"
+def test_get_actor_ip_ignores_forwarded_chain_when_proxy_is_not_trusted():
+    previous = settings.trusted_proxy_ips
+    try:
+        settings.trusted_proxy_ips = []
+        req = _request(actor_ip="203.0.113.10", forwarded_for="192.168.1.10, 10.0.0.1")
+        assert _get_actor_ip(req) == "203.0.113.10"
+    finally:
+        settings.trusted_proxy_ips = previous
+
+
+def test_get_actor_ip_uses_forwarded_chain_when_proxy_is_trusted():
+    previous = settings.trusted_proxy_ips
+    try:
+        settings.trusted_proxy_ips = ["203.0.113.10"]
+        req = _request(actor_ip="203.0.113.10", forwarded_for="192.168.1.10, 10.0.0.1")
+        assert _get_actor_ip(req) == "192.168.1.10"
+    finally:
+        settings.trusted_proxy_ips = previous
+
+
+def test_forwarded_chain_is_normalized():
+    req = _request(forwarded_for=" 192.168.1.10, invalid-ip,10.0.0.1 ")
+    assert _forwarded_chain(req) == "192.168.1.10,10.0.0.1"
 
 
 @pytest.mark.anyio

--- a/wiki/APIs-e-Integracao.md
+++ b/wiki/APIs-e-Integracao.md
@@ -255,6 +255,7 @@ Usada pelo dashboard para atualizações em tempo real sem polling.
 **Autenticação obrigatória**:
 - `X-API-Key: <DASHBOARD_API_KEY>`
 - ou `Authorization: Bearer <DASHBOARD_API_KEY>`
+- Para auditoria de IP atrás de proxy reverso, configurar `TRUSTED_PROXY_IPS` no backend.
 
 ### WebSocket do Dashboard (`/ws`)
 

--- a/wiki/Issue-Resolution-Log.md
+++ b/wiki/Issue-Resolution-Log.md
@@ -34,3 +34,4 @@ Registro cronológico de fechamento das issues de pendências documentais e de c
 | #715 | high | `k8s/base/dashboard/dashboard.yaml`, `src/dashboard/frontend/nginx.conf.template`, `scripts/check-hardcoded-secrets.sh` | fechado | 2026-03-02 |
 | #716 | high | `src/dashboard/backend/app/security.py`, `src/dashboard/frontend/src/hooks/useWebSocket.js`, `tests/backend/test_ws_browser_auth.py` | fechado | 2026-03-02 |
 | #717 | high | `src/dashboard/frontend/src/utils/auth.js`, `src/dashboard/frontend/src/hooks/useAssets.js`, `tests/backend/test_dashboard_auth_parity_contract.py` | fechado | 2026-03-02 |
+| #718 | high | `src/dashboard/backend/app/routers/assets.py`, `src/dashboard/backend/app/config.py`, `src/dashboard/backend/migrations/versions/20260302_0004_asset_audit_forwarded_chain.py` | fechado | 2026-03-02 |

--- a/wiki/Seguranca-e-Compliance.md
+++ b/wiki/Seguranca-e-Compliance.md
@@ -132,6 +132,13 @@ BACKUP_ENCRYPTION_PASSPHRASE=<senha forte>
 - O fluxo de autenticação agora é do cliente para backend em ambos os ambientes (Vite e Nginx), sem injeção de chave estática no proxy.
 - Teste de contrato valida que `vite.config.js` e `nginx.conf.template` não injetam headers de autenticação.
 
+## Auditoria de IP com trusted proxies (Issue #718)
+
+- A trilha de auditoria de ativos passou a usar `TRUSTED_PROXY_IPS` para decidir quando aceitar `X-Forwarded-For`.
+- Quando a origem não é proxy confiável, o sistema registra `request.client.host` como IP efetivo.
+- A cadeia normalizada de forwarding (`X-Forwarded-For`) é persistida separadamente em `asset_audit.actor_ip_chain`.
+- Testes cobrem cenários com proxy confiável e sem proxy confiável.
+
 ---
 
 ## Hardening do Servidor


### PR DESCRIPTION
## Resumo
Resolve a issue #718 fortalecendo a auditoria de IP com validação de trusted proxies.

## Mudanças
- adiciona configuração TRUSTED_PROXY_IPS no backend
- aceita X-Forwarded-For somente quando a origem da requisição é proxy confiável
- mantém request.client.host como IP efetivo para clientes diretos
- normaliza e persiste a cadeia de forwarding em asset_audit.actor_ip_chain
- inclui migração Alembic para novo campo de auditoria
- adiciona testes cobrindo cenários com e sem proxy confiável
- atualiza .env.example e wiki

## Validação local
- python3 -m py_compile src/dashboard/backend/app/config.py src/dashboard/backend/app/db/models.py src/dashboard/backend/app/routers/assets.py src/dashboard/backend/migrations/versions/20260302_0004_asset_audit_forwarded_chain.py tests/backend/test_assets_router_coverage.py
- não foi possível rodar pytest completo neste ambiente por ausência de dependências Python instaladas

Closes #718
