### PR TITLE
fix: observabilidade de falhas em integrações críticas (#719)

### DIFF
--- a/src/dashboard/backend/app/routers/services.py
+++ b/src/dashboard/backend/app/routers/services.py
@@ -1,8 +1,11 @@
 import httpx
 from fastapi import APIRouter
+import logging
 
 from app.config import settings
-from app.services import ha_client
+from app.services import frigate_client, ha_client
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/services", tags=["services"])
 
@@ -12,6 +15,9 @@ SERVICES_TO_CHECK = {
 }
 
 _client: httpx.AsyncClient | None = None
+_metrics = {
+    "status_check_failures_total": 0,
+}
 
 
 async def get_client() -> httpx.AsyncClient:
@@ -41,7 +47,9 @@ async def _check_http(url: str) -> str:
             else {},
         )
         return "online" if resp.status_code < 500 else "degraded"
-    except Exception:
+    except (httpx.RequestError, httpx.TimeoutException) as exc:
+        _metrics["status_check_failures_total"] += 1
+        logger.warning("Service status check failed", exc_info=True, extra={"url": url, "error": str(exc)})
         return "offline"
 
 
@@ -61,4 +69,10 @@ async def services_status() -> dict:
 @router.get("/ws-metrics")
 async def ws_metrics() -> dict:
     """Retorna métricas operacionais do fan-out WebSocket."""
-    return {"ws_metrics": ha_client.get_ws_metrics()}
+    return {
+        "ws_metrics": ha_client.get_ws_metrics(),
+        "integration_metrics": {
+            "services_router": dict(_metrics),
+            "frigate_client": frigate_client.get_metrics(),
+        },
+    }

--- a/src/dashboard/backend/app/routers/ws.py
+++ b/src/dashboard/backend/app/routers/ws.py
@@ -54,7 +54,8 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
 
     except WebSocketDisconnect:
         logger.info("Cliente WS desconectado.")
-    except Exception as exc:
-        logger.warning("Erro no WebSocket: %s", exc)
+    except (RuntimeError, ValueError, TypeError) as exc:
+        ha_client.record_ws_handler_failure()
+        logger.warning("Erro no WebSocket", exc_info=True, extra={"error": str(exc)})
     finally:
         ha_client.unsubscribe(enqueue)

--- a/src/dashboard/backend/app/services/frigate_client.py
+++ b/src/dashboard/backend/app/services/frigate_client.py
@@ -1,10 +1,22 @@
 """Cliente HTTP para o Frigate NVR."""
 
+import logging
+
 import httpx
 
 from app.config import settings
 
 _client: httpx.AsyncClient | None = None
+logger = logging.getLogger(__name__)
+_metrics = {
+    "snapshot_failures_total": 0,
+    "events_failures_total": 0,
+    "stats_failures_total": 0,
+}
+
+
+def get_metrics() -> dict[str, int]:
+    return dict(_metrics)
 
 
 async def get_client() -> httpx.AsyncClient:
@@ -32,8 +44,11 @@ async def get_snapshot(camera_name: str) -> bytes | None:
         resp = await client.get(url)
         if resp.status_code == 200:
             return resp.content
-    except httpx.RequestError:
-        pass
+        _metrics["snapshot_failures_total"] += 1
+        logger.warning("Frigate snapshot unavailable", extra={"camera": camera_name, "status_code": resp.status_code})
+    except httpx.RequestError as exc:
+        _metrics["snapshot_failures_total"] += 1
+        logger.warning("Frigate snapshot request failed", exc_info=True, extra={"camera": camera_name, "error": str(exc)})
     return None
 
 
@@ -53,8 +68,17 @@ async def get_events(
         resp = await client.get(f"{settings.frigate_url}/api/events", params=params)
         if resp.status_code == 200:
             return resp.json()
-    except httpx.RequestError:
-        pass
+        _metrics["events_failures_total"] += 1
+        logger.warning(
+            "Frigate events unavailable",
+            extra={"camera": camera, "label": label, "status_code": resp.status_code},
+        )
+    except httpx.RequestError as exc:
+        _metrics["events_failures_total"] += 1
+        logger.warning("Frigate events request failed", exc_info=True, extra={"camera": camera, "label": label, "error": str(exc)})
+    except ValueError as exc:
+        _metrics["events_failures_total"] += 1
+        logger.warning("Frigate events payload is not valid JSON", exc_info=True, extra={"camera": camera, "label": label, "error": str(exc)})
     return []
 
 
@@ -65,6 +89,12 @@ async def get_stats() -> dict:
         resp = await client.get(f"{settings.frigate_url}/api/stats")
         if resp.status_code == 200:
             return resp.json()
-    except httpx.RequestError:
-        pass
+        _metrics["stats_failures_total"] += 1
+        logger.warning("Frigate stats unavailable", extra={"status_code": resp.status_code})
+    except httpx.RequestError as exc:
+        _metrics["stats_failures_total"] += 1
+        logger.warning("Frigate stats request failed", exc_info=True, extra={"error": str(exc)})
+    except ValueError as exc:
+        _metrics["stats_failures_total"] += 1
+        logger.warning("Frigate stats payload is not valid JSON", exc_info=True, extra={"error": str(exc)})
     return {}

--- a/src/dashboard/backend/app/services/ha_client.py
+++ b/src/dashboard/backend/app/services/ha_client.py
@@ -34,6 +34,10 @@ _metrics = {
     "messages_dropped_total": 0,
     "messages_fanout_total": 0,
     "fanout_failures_total": 0,
+    "ws_handler_failures_total": 0,
+    "initial_state_fetch_failures_total": 0,
+    "event_decode_failures_total": 0,
+    "unexpected_errors_total": 0,
 }
 
 
@@ -81,6 +85,10 @@ def get_ws_metrics() -> dict[str, int]:
     }
 
 
+def record_ws_handler_failure() -> None:
+    _metrics["ws_handler_failures_total"] += 1
+
+
 def _severity_for(entity_id: str, new_state: str) -> str:
     """Determina severidade de um evento com base na entidade e estado."""
     if entity_id == "alarm_control_panel.alarmo":
@@ -123,8 +131,9 @@ async def _fan_out(message: dict) -> None:
         try:
             await cb(payload)
             _metrics["messages_fanout_total"] += 1
-        except Exception:
+        except (RuntimeError, ValueError, TypeError) as exc:
             _metrics["fanout_failures_total"] += 1
+            logger.warning("Falha no fan-out para cliente WS", exc_info=True, extra={"error": str(exc)})
             dead.add(cb)
     _subscribers.difference_update(dead)
 
@@ -137,12 +146,22 @@ async def _fetch_initial_states() -> None:
             f"{settings.ha_url}/api/states",
             headers={"Authorization": f"Bearer {settings.ha_token}"},
         )
-        if resp.status_code == 200:
-            for state in resp.json():
-                _entity_states[state["entity_id"]] = state
-            logger.info("Estados iniciais carregados: %d entidades", len(_entity_states))
-    except Exception as exc:
-        logger.warning("Não foi possível carregar estados iniciais: %s", exc)
+        if resp.status_code != 200:
+            _metrics["initial_state_fetch_failures_total"] += 1
+            logger.warning(
+                "Não foi possível carregar estados iniciais",
+                extra={"status_code": resp.status_code},
+            )
+            return
+        for state in resp.json():
+            _entity_states[state["entity_id"]] = state
+        logger.info("Estados iniciais carregados: %d entidades", len(_entity_states))
+    except httpx.RequestError as exc:
+        _metrics["initial_state_fetch_failures_total"] += 1
+        logger.warning("Erro de rede ao carregar estados iniciais", exc_info=True, extra={"error": str(exc)})
+    except ValueError as exc:
+        _metrics["initial_state_fetch_failures_total"] += 1
+        logger.warning("Payload inválido ao carregar estados iniciais", exc_info=True, extra={"error": str(exc)})
 
 
 def _build_ws_url() -> str:
@@ -209,7 +228,12 @@ async def _process_event_message(msg: dict[str, Any]) -> None:
 
 async def _consume_events(ws: Any) -> None:
     async for raw in ws:
-        msg: dict[str, Any] = json.loads(raw)
+        try:
+            msg: dict[str, Any] = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            _metrics["event_decode_failures_total"] += 1
+            logger.warning("Mensagem WS do HA com JSON inválido", exc_info=True, extra={"error": str(exc)})
+            continue
         if msg.get("type") != "event":
             continue
         await _process_event_message(msg)
@@ -249,6 +273,14 @@ async def run_forever() -> None:
         except (websockets.exceptions.ConnectionClosed, OSError, asyncio.TimeoutError) as exc:
             logger.warning("Conexão HA perdida: %s. Reconectando em %ds…", exc, backoff)
             backoff = await _sleep_with_backoff(backoff)
-        except Exception as exc:
-            logger.error("Erro inesperado no cliente HA: %s", exc, exc_info=True)
+        except (
+            websockets.exceptions.WebSocketException,
+            json.JSONDecodeError,
+            httpx.RequestError,
+            RuntimeError,
+            ValueError,
+            TypeError,
+        ) as exc:
+            _metrics["unexpected_errors_total"] += 1
+            logger.error("Erro no cliente HA", exc_info=True, extra={"error": str(exc)})
             backoff = await _sleep_with_backoff(backoff)

--- a/tests/backend/test_integration_error_handling_contract.py
+++ b/tests/backend/test_integration_error_handling_contract.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TARGETS = [
+    ROOT / "src" / "dashboard" / "backend" / "app" / "services" / "ha_client.py",
+    ROOT / "src" / "dashboard" / "backend" / "app" / "services" / "frigate_client.py",
+    ROOT / "src" / "dashboard" / "backend" / "app" / "routers" / "services.py",
+    ROOT / "src" / "dashboard" / "backend" / "app" / "routers" / "ws.py",
+]
+
+
+def test_critical_integrations_do_not_swallow_generic_exceptions():
+    for path in TARGETS:
+        content = path.read_text(encoding="utf-8")
+        assert "except Exception" not in content, f"Generic exception handler found in {path.name}"
+        assert "\n        pass\n" not in content, f"Silent pass found in {path.name}"

--- a/wiki/APIs-e-Integracao.md
+++ b/wiki/APIs-e-Integracao.md
@@ -266,6 +266,7 @@ Usada pelo dashboard para atualizações em tempo real sem polling.
 | Método | Rota | Descrição |
 |--------|------|-----------|
 | `GET` | `/health` | Healthcheck (Docker/K8s probe) |
+| `GET` | `/api/services/ws-metrics` | Métricas de fan-out WS e falhas de integração |
 | `WS` | `/ws` | WebSocket — fan-out de eventos HA |
 | `GET` | `/api/sensors` | Todos os estados de entidades HA |
 | `GET` | `/api/sensors/{entity_id}` | Estado de uma entidade |

--- a/wiki/Issue-Resolution-Log.md
+++ b/wiki/Issue-Resolution-Log.md
@@ -35,3 +35,4 @@ Registro cronológico de fechamento das issues de pendências documentais e de c
 | #716 | high | `src/dashboard/backend/app/security.py`, `src/dashboard/frontend/src/hooks/useWebSocket.js`, `tests/backend/test_ws_browser_auth.py` | fechado | 2026-03-02 |
 | #717 | high | `src/dashboard/frontend/src/utils/auth.js`, `src/dashboard/frontend/src/hooks/useAssets.js`, `tests/backend/test_dashboard_auth_parity_contract.py` | fechado | 2026-03-02 |
 | #718 | high | `src/dashboard/backend/app/routers/assets.py`, `src/dashboard/backend/app/config.py`, `src/dashboard/backend/migrations/versions/20260302_0004_asset_audit_forwarded_chain.py` | fechado | 2026-03-02 |
+| #719 | high | `src/dashboard/backend/app/services/ha_client.py`, `src/dashboard/backend/app/services/frigate_client.py`, `src/dashboard/backend/app/routers/services.py`, `src/dashboard/backend/app/routers/ws.py` | fechado | 2026-03-02 |

--- a/wiki/Seguranca-e-Compliance.md
+++ b/wiki/Seguranca-e-Compliance.md
@@ -139,6 +139,13 @@ BACKUP_ENCRYPTION_PASSPHRASE=<senha forte>
 - A cadeia normalizada de forwarding (`X-Forwarded-For`) é persistida separadamente em `asset_audit.actor_ip_chain`.
 - Testes cobrem cenários com proxy confiável e sem proxy confiável.
 
+## Observabilidade de integrações críticas (Issue #719)
+
+- Rotas e clientes de integração (HA, Frigate e WebSocket) deixaram de usar `except Exception` genérico e `pass` silencioso.
+- Falhas de integração agora geram log estruturado com contexto de erro.
+- Métricas de falha foram expostas em `/api/services/ws-metrics` para HA/Frigate/checagem de status.
+- Teste de contrato garante ausência de swallow genérico nos caminhos críticos de integração.
+
 ---
 
 ## Hardening do Servidor


### PR DESCRIPTION
## Resumo
Resolve a issue #719 removendo tratamento silencioso de falhas em integrações críticas e adicionando observabilidade por logs e métricas.

## Mudanças
- substitui handlers genéricos e swallow em HA/Frigate/routers críticos
- adiciona logging estruturado com contexto de erro nas integrações
- adiciona contadores de falha em ha_client e frigate_client
- expõe métricas de integração em /api/services/ws-metrics
- adiciona teste de contrato para bloquear regressão de except Exception/pass
- atualiza wiki de segurança, integração e log de resolução

## Validação local
- python3 -m py_compile src/dashboard/backend/app/services/ha_client.py src/dashboard/backend/app/services/frigate_client.py src/dashboard/backend/app/routers/services.py src/dashboard/backend/app/routers/ws.py tests/backend/test_integration_error_handling_contract.py
- pytest completo não pôde ser executado neste ambiente por ausência de dependências Python instaladas

Closes #719
