### PR TITLE
fix: RBAC admin em mutações do mapa operacional (#720)

### DIFF
--- a/src/dashboard/backend/app/routers/alerts.py
+++ b/src/dashboard/backend/app/routers/alerts.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models import Alert, Asset, DashboardConfig, DevicePosition
 from app.db.session import get_db
+from app.security import require_admin_key
 
 router = APIRouter(prefix="/api", tags=["alerts"])
 MAP_FLOORPLAN_IMAGE_KEY = "map.floorplan_image_data_url"
@@ -127,7 +128,7 @@ async def get_map_config(db: AsyncSession = Depends(get_db)) -> dict:
     }
 
 
-@router.put("/map/config")
+@router.put("/map/config", dependencies=[Depends(require_admin_key)])
 async def upsert_map_config(payload: MapConfigPayload, db: AsyncSession = Depends(get_db)) -> dict:
     if payload.floorplan_image_data_url is not None:
         await db.merge(

--- a/src/dashboard/frontend/src/components/OperationalMap.jsx
+++ b/src/dashboard/frontend/src/components/OperationalMap.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import useStore from '../store/useStore'
-import { apiFetch } from '../utils/auth'
+import { apiFetch, withAdminHeaders } from '../utils/auth'
 
 const DEFAULT_DEVICES = [
   { entity_id: 'camera.cam_entrada', label: 'Câm Entrada', x: 50, y: 5, device_type: 'camera' },
@@ -147,7 +147,7 @@ export default function OperationalMap() {
   async function saveMapConfig(nextConfig) {
     const resp = await apiFetch('/api/map/config', {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
+      headers: withAdminHeaders({ 'Content-Type': 'application/json' }),
       body: JSON.stringify(nextConfig),
     })
     if (!resp.ok) throw new Error('failed to save map config')

--- a/src/dashboard/frontend/src/pages/AssetsAdmin.jsx
+++ b/src/dashboard/frontend/src/pages/AssetsAdmin.jsx
@@ -300,6 +300,15 @@ export default function AssetsAdmin() {
     setFilterType(initialType)
   }, [initialType])
 
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    if (adminKey) {
+      window.sessionStorage.setItem('dashboard_admin_key', adminKey)
+      return
+    }
+    window.sessionStorage.removeItem('dashboard_admin_key')
+  }, [adminKey])
+
   function showFeedback(msg, isError = false) {
     setFeedback({ msg, isError })
     setTimeout(() => setFeedback(null), 4000)

--- a/src/dashboard/frontend/src/utils/auth.js
+++ b/src/dashboard/frontend/src/utils/auth.js
@@ -1,4 +1,5 @@
 const TOKEN_STORAGE_KEY = "dashboard_api_key";
+const ADMIN_KEY_STORAGE = "dashboard_admin_key";
 
 function readTokenFromStorage() {
   if (typeof window === "undefined") return null;
@@ -29,6 +30,24 @@ export function withApiAuthHeaders(headers = {}) {
   return {
     ...headers,
     Authorization: `Bearer ${token}`,
+  };
+}
+
+export function getAdminKey() {
+  if (typeof window === "undefined") return null;
+  return (
+    window.sessionStorage.getItem(ADMIN_KEY_STORAGE) ||
+    window.localStorage.getItem(ADMIN_KEY_STORAGE) ||
+    null
+  );
+}
+
+export function withAdminHeaders(headers = {}) {
+  const adminKey = getAdminKey();
+  if (!adminKey) return headers;
+  return {
+    ...headers,
+    "X-Admin-Key": adminKey,
   };
 }
 

--- a/tests/backend/test_map_config_payload_security_contract.py
+++ b/tests/backend/test_map_config_payload_security_contract.py
@@ -12,3 +12,8 @@ def test_map_config_payload_has_size_and_format_validation():
     assert "floorplan image payload exceeds maximum allowed size" in content
     assert "data:image/" in content
     assert ";base64," in content
+
+
+def test_map_config_put_requires_admin_key_dependency():
+    content = ALERTS_ROUTER.read_text(encoding="utf-8")
+    assert '@router.put("/map/config", dependencies=[Depends(require_admin_key)])' in content

--- a/tests/backend/test_map_config_rbac.py
+++ b/tests/backend/test_map_config_rbac.py
@@ -1,0 +1,101 @@
+import httpx
+import pytest
+from fastapi import Depends, FastAPI
+
+from app.config import settings
+from app.db.session import get_db
+from app.routers import alerts
+from app.security import require_api_key
+
+TEST_BASE_URL = "http://testserver"
+
+
+class _FakeResult:
+    def scalars(self):
+        return self
+
+    def all(self):
+        return []
+
+
+class _FakeSession:
+    async def execute(self, _stmt):
+        return _FakeResult()
+
+    async def merge(self, _obj):
+        return None
+
+    async def commit(self):
+        return None
+
+
+async def _override_get_db():
+    yield _FakeSession()
+
+
+def _build_test_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(alerts.router, dependencies=[Depends(require_api_key)])
+    app.dependency_overrides[get_db] = _override_get_db
+    return app
+
+
+@pytest.mark.anyio
+async def test_put_map_config_requires_admin_key_when_configured():
+    previous = settings.dashboard_admin_key
+    settings.dashboard_admin_key = "test-admin-key"
+    app = _build_test_app()
+    transport = httpx.ASGITransport(app=app)
+
+    try:
+        async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+            resp = await client.put(
+                "/api/map/config",
+                headers={"X-API-Key": "test-api-key"},
+                json={"geo_bounds": {"min_lat": -1, "max_lat": 1, "min_lon": -1, "max_lon": 1}},
+            )
+        assert resp.status_code == 403
+    finally:
+        settings.dashboard_admin_key = previous
+
+
+@pytest.mark.anyio
+async def test_put_map_config_returns_503_when_admin_key_not_configured():
+    previous = settings.dashboard_admin_key
+    settings.dashboard_admin_key = ""
+    app = _build_test_app()
+    transport = httpx.ASGITransport(app=app)
+
+    try:
+        async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+            resp = await client.put(
+                "/api/map/config",
+                headers={"X-API-Key": "test-api-key"},
+                json={"geo_bounds": {"min_lat": -1, "max_lat": 1, "min_lon": -1, "max_lon": 1}},
+            )
+        assert resp.status_code == 503
+    finally:
+        settings.dashboard_admin_key = previous
+
+
+@pytest.mark.anyio
+async def test_put_map_config_allows_admin_key():
+    previous = settings.dashboard_admin_key
+    settings.dashboard_admin_key = "test-admin-key"
+    app = _build_test_app()
+    transport = httpx.ASGITransport(app=app)
+
+    try:
+        async with httpx.AsyncClient(transport=transport, base_url=TEST_BASE_URL) as client:
+            resp = await client.put(
+                "/api/map/config",
+                headers={
+                    "X-API-Key": "test-api-key",
+                    "X-Admin-Key": "test-admin-key",
+                },
+                json={"geo_bounds": {"min_lat": -1, "max_lat": 1, "min_lon": -1, "max_lon": 1}},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+    finally:
+        settings.dashboard_admin_key = previous

--- a/wiki/APIs-e-Integracao.md
+++ b/wiki/APIs-e-Integracao.md
@@ -267,6 +267,7 @@ Usada pelo dashboard para atualizações em tempo real sem polling.
 |--------|------|-----------|
 | `GET` | `/health` | Healthcheck (Docker/K8s probe) |
 | `GET` | `/api/services/ws-metrics` | Métricas de fan-out WS e falhas de integração |
+| `PUT` | `/api/map/config` | Atualiza mapa operacional (requer `X-Admin-Key`) |
 | `WS` | `/ws` | WebSocket — fan-out de eventos HA |
 | `GET` | `/api/sensors` | Todos os estados de entidades HA |
 | `GET` | `/api/sensors/{entity_id}` | Estado de uma entidade |

--- a/wiki/Issue-Resolution-Log.md
+++ b/wiki/Issue-Resolution-Log.md
@@ -36,3 +36,4 @@ Registro cronológico de fechamento das issues de pendências documentais e de c
 | #717 | high | `src/dashboard/frontend/src/utils/auth.js`, `src/dashboard/frontend/src/hooks/useAssets.js`, `tests/backend/test_dashboard_auth_parity_contract.py` | fechado | 2026-03-02 |
 | #718 | high | `src/dashboard/backend/app/routers/assets.py`, `src/dashboard/backend/app/config.py`, `src/dashboard/backend/migrations/versions/20260302_0004_asset_audit_forwarded_chain.py` | fechado | 2026-03-02 |
 | #719 | high | `src/dashboard/backend/app/services/ha_client.py`, `src/dashboard/backend/app/services/frigate_client.py`, `src/dashboard/backend/app/routers/services.py`, `src/dashboard/backend/app/routers/ws.py` | fechado | 2026-03-02 |
+| #720 | high | `src/dashboard/backend/app/routers/alerts.py`, `tests/backend/test_map_config_rbac.py`, `src/dashboard/frontend/src/components/OperationalMap.jsx` | fechado | 2026-03-02 |

--- a/wiki/Seguranca-e-Compliance.md
+++ b/wiki/Seguranca-e-Compliance.md
@@ -146,6 +146,13 @@ BACKUP_ENCRYPTION_PASSPHRASE=<senha forte>
 - Métricas de falha foram expostas em `/api/services/ws-metrics` para HA/Frigate/checagem de status.
 - Teste de contrato garante ausência de swallow genérico nos caminhos críticos de integração.
 
+## RBAC admin para configuração de mapa (Issue #720)
+
+- O endpoint `PUT /api/map/config` agora exige `require_admin_key`.
+- Leitura de mapa (`GET /api/map/config`) permanece disponível no perfil operator.
+- Testes cobrem cenários de autorização do `PUT` para 403, 503 e 200.
+- O frontend passou a enviar `X-Admin-Key` para mutações do mapa quando a chave admin está presente em sessão.
+
 ---
 
 ## Hardening do Servidor


### PR DESCRIPTION
## Resumo
Resolve a issue #720 aplicando RBAC admin para mutações da configuração do mapa operacional.

## Mudanças
- adiciona `require_admin_key` em `PUT /api/map/config`
- mantém leitura de mapa (`GET /api/map/config`) no escopo operator
- frontend envia `X-Admin-Key` em gravações do mapa quando chave admin existe em sessão
- `AssetsAdmin` persiste a chave admin em `sessionStorage` para reaproveitamento no dashboard
- adiciona testes de autorização do endpoint para cenários 403/503/200
- adiciona teste de contrato para garantir dependência admin no `PUT`
- atualiza wiki de integração/segurança e log de resolução

## Validação local
- python3 -m py_compile src/dashboard/backend/app/routers/alerts.py tests/backend/test_map_config_rbac.py tests/backend/test_map_config_payload_security_contract.py
- pytest completo não pôde ser executado neste ambiente por ausência de dependências Python instaladas

Closes #720
