### PR TITLE
chore: gate de non-root para manifests K8s (#721)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Block hardcoded secrets/placeholders in changed YAML/CONF
         run: bash scripts/check-hardcoded-secrets.sh
 
+      - name: Enforce K8s non-root policy in changed manifests
+        run: bash scripts/check-k8s-non-root-policy.sh
+
   lint-yaml:
     name: Lint YAML
     runs-on: ubuntu-latest

--- a/scripts/check-k8s-non-root-policy.sh
+++ b/scripts/check-k8s-non-root-policy.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${1:-}"
+
+if [[ -z "${BASE_REF}" ]]; then
+  if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+    BASE_REF="origin/${GITHUB_BASE_REF}"
+  elif git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+    BASE_REF="HEAD~1"
+  else
+    BASE_REF="HEAD"
+  fi
+fi
+
+changed_files="$(git diff --name-only --diff-filter=ACMRT "${BASE_REF}"...HEAD || true)"
+target_files="$(echo "${changed_files}" | grep -E '^k8s/.*\.ya?ml$' || true)"
+
+if [[ -z "${target_files}" ]]; then
+  echo "No changed K8s YAML files to scan."
+  exit 0
+fi
+
+echo "Scanning changed K8s manifests for runAsNonRoot policy..."
+echo "${target_files}" | sed 's/^/ - /'
+
+failed=0
+while IFS= read -r file; do
+  [[ -z "${file}" ]] && continue
+  [[ -f "${file}" ]] || continue
+
+  if grep -nE '^[[:space:]]*runAsNonRoot:[[:space:]]*false[[:space:]]*$' "${file}" >/dev/null; then
+    if grep -q "SECURITY_EXCEPTION_RUN_AS_NON_ROOT_FALSE" "${file}"; then
+      echo "[WARN] runAsNonRoot=false found with documented exception in ${file}"
+      continue
+    fi
+    echo "[FAIL] runAsNonRoot=false without documented exception in ${file}:"
+    grep -nE '^[[:space:]]*runAsNonRoot:[[:space:]]*false[[:space:]]*$' "${file}" || true
+    failed=1
+  fi
+done <<< "${target_files}"
+
+if [[ "${failed}" -ne 0 ]]; then
+  echo "K8s non-root policy check failed."
+  exit 1
+fi
+
+echo "K8s non-root policy check passed."

--- a/wiki/Issue-Resolution-Log.md
+++ b/wiki/Issue-Resolution-Log.md
@@ -37,3 +37,4 @@ Registro cronológico de fechamento das issues de pendências documentais e de c
 | #718 | high | `src/dashboard/backend/app/routers/assets.py`, `src/dashboard/backend/app/config.py`, `src/dashboard/backend/migrations/versions/20260302_0004_asset_audit_forwarded_chain.py` | fechado | 2026-03-02 |
 | #719 | high | `src/dashboard/backend/app/services/ha_client.py`, `src/dashboard/backend/app/services/frigate_client.py`, `src/dashboard/backend/app/routers/services.py`, `src/dashboard/backend/app/routers/ws.py` | fechado | 2026-03-02 |
 | #720 | high | `src/dashboard/backend/app/routers/alerts.py`, `tests/backend/test_map_config_rbac.py`, `src/dashboard/frontend/src/components/OperationalMap.jsx` | fechado | 2026-03-02 |
+| #721 | high | `k8s/base/dashboard/dashboard.yaml`, `scripts/check-k8s-non-root-policy.sh`, `.github/workflows/validate.yml` | fechado | 2026-03-02 |

--- a/wiki/Seguranca-e-Compliance.md
+++ b/wiki/Seguranca-e-Compliance.md
@@ -153,6 +153,12 @@ BACKUP_ENCRYPTION_PASSPHRASE=<senha forte>
 - Testes cobrem cenários de autorização do `PUT` para 403, 503 e 200.
 - O frontend passou a enviar `X-Admin-Key` para mutações do mapa quando a chave admin está presente em sessão.
 
+## Hardening K8s do dashboard (Issue #721)
+
+- Deployment da API do dashboard executa em modo non-root (`runAsNonRoot: true`, UID/GID dedicados).
+- Variáveis sensíveis do dashboard (`HA_TOKEN`, `DATABASE_URL`, `DASHBOARD_API_KEY`, `DASHBOARD_ADMIN_KEY`) são consumidas por `secretKeyRef`.
+- O CI executa `scripts/check-k8s-non-root-policy.sh` para bloquear novos `runAsNonRoot: false` em manifests alterados sem exceção documentada (`SECURITY_EXCEPTION_RUN_AS_NON_ROOT_FALSE`).
+
 ---
 
 ## Hardening do Servidor


### PR DESCRIPTION
## Resumo
Resolve a issue #721 adicionando enforcement de hardening non-root no CI para manifests K8s alterados.

## Mudanças
- adiciona `scripts/check-k8s-non-root-policy.sh`
- bloqueia `runAsNonRoot: false` em YAMLs K8s alterados sem exceção documentada
- permite exceção apenas com marcador explícito `SECURITY_EXCEPTION_RUN_AS_NON_ROOT_FALSE`
- integra gate no workflow `validate.yml` (job de hygiene)
- atualiza wiki de segurança e log de resolução

## Validação local
- bash -n scripts/check-k8s-non-root-policy.sh
- testes CI completos não executados localmente

Closes #721
