### PR TITLE
chore: consolidar .gitignore e gate de artefatos (#722)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Enforce K8s non-root policy in changed manifests
         run: bash scripts/check-k8s-non-root-policy.sh
 
+      - name: Block generated artifacts in changed paths
+        run: bash scripts/check-generated-artifacts.sh
+
   lint-yaml:
     name: Lint YAML
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,10 @@ src/mosquitto/certs/server.crt
 # Sonar scanner local artifacts
 .scannerwork/
 .sonar-local/
+
+# Generated artifacts (Node/Python/tests)
+**/node_modules/
+**/coverage/
+**/__pycache__/
+.coverage
+**/.coverage

--- a/scripts/check-generated-artifacts.sh
+++ b/scripts/check-generated-artifacts.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${1:-}"
+
+if [[ -z "${BASE_REF}" ]]; then
+  if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+    BASE_REF="origin/${GITHUB_BASE_REF}"
+  elif git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+    BASE_REF="HEAD~1"
+  else
+    BASE_REF="HEAD"
+  fi
+fi
+
+changed_paths="$(git diff --name-only --diff-filter=ACMRT "${BASE_REF}"...HEAD || true)"
+
+if [[ -z "${changed_paths}" ]]; then
+  echo "No changed files to inspect."
+  exit 0
+fi
+
+artifact_hits="$(echo "${changed_paths}" | grep -E '(^|/)(node_modules|coverage|__pycache__)(/|$)|(^|/)\.coverage$' || true)"
+
+if [[ -n "${artifact_hits}" ]]; then
+  echo "[FAIL] Generated artifacts detected in changed paths:"
+  echo "${artifact_hits}" | sed 's/^/ - /'
+  exit 1
+fi
+
+echo "Generated artifact check passed."

--- a/wiki/Issue-Resolution-Log.md
+++ b/wiki/Issue-Resolution-Log.md
@@ -38,3 +38,4 @@ Registro cronológico de fechamento das issues de pendências documentais e de c
 | #719 | high | `src/dashboard/backend/app/services/ha_client.py`, `src/dashboard/backend/app/services/frigate_client.py`, `src/dashboard/backend/app/routers/services.py`, `src/dashboard/backend/app/routers/ws.py` | fechado | 2026-03-02 |
 | #720 | high | `src/dashboard/backend/app/routers/alerts.py`, `tests/backend/test_map_config_rbac.py`, `src/dashboard/frontend/src/components/OperationalMap.jsx` | fechado | 2026-03-02 |
 | #721 | high | `k8s/base/dashboard/dashboard.yaml`, `scripts/check-k8s-non-root-policy.sh`, `.github/workflows/validate.yml` | fechado | 2026-03-02 |
+| #722 | medium | `.gitignore`, `scripts/check-generated-artifacts.sh`, `.github/workflows/validate.yml` | fechado | 2026-03-02 |

--- a/wiki/Seguranca-e-Compliance.md
+++ b/wiki/Seguranca-e-Compliance.md
@@ -159,6 +159,11 @@ BACKUP_ENCRYPTION_PASSPHRASE=<senha forte>
 - Variáveis sensíveis do dashboard (`HA_TOKEN`, `DATABASE_URL`, `DASHBOARD_API_KEY`, `DASHBOARD_ADMIN_KEY`) são consumidas por `secretKeyRef`.
 - O CI executa `scripts/check-k8s-non-root-policy.sh` para bloquear novos `runAsNonRoot: false` em manifests alterados sem exceção documentada (`SECURITY_EXCEPTION_RUN_AS_NON_ROOT_FALSE`).
 
+## Higiene de artefatos no repositório (Issue #722)
+
+- `.gitignore` raiz passou a cobrir artefatos gerados de Node/Python/testes (`node_modules`, `coverage`, `__pycache__`, `.coverage`) em todo o monorepo.
+- O CI executa `scripts/check-generated-artifacts.sh` para bloquear artefatos gerados em arquivos alterados de PR/push.
+
 ---
 
 ## Hardening do Servidor


### PR DESCRIPTION
## Resumo
Resolve a issue #722 consolidando a higiene de artefatos gerados no monorepo.

## Mudanças
- amplia `.gitignore` raiz com regras globais para `node_modules`, `coverage`, `__pycache__` e `.coverage`
- adiciona `scripts/check-generated-artifacts.sh`
- integra o novo gate no workflow `validate.yml`
- atualiza wiki de segurança e log de resolução

## Validação local
- bash -n scripts/check-generated-artifacts.sh

Closes #722
