### PR TITLE
test: fechar lacunas de cobertura em caminhos críticos frontend (#723)

### DIFF
--- a/src/dashboard/frontend/src/components/OperationalMap.test.jsx
+++ b/src/dashboard/frontend/src/components/OperationalMap.test.jsx
@@ -1,0 +1,118 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import OperationalMap from "./OperationalMap";
+
+const apiFetch = vi.fn();
+
+vi.mock("../store/useStore", () => ({
+  default: () => ({
+    states: {
+      "sensor.ugv_battery": { state: "81" },
+      "sensor.uav_battery": { state: "72" },
+    },
+  }),
+}));
+
+vi.mock("../utils/auth", () => ({
+  apiFetch: (...args) => apiFetch(...args),
+  withAdminHeaders: (headers) => headers,
+}));
+
+function setupDefaultApiFetch() {
+  apiFetch.mockImplementation(async (url, options = {}) => {
+    if (url === "/api/map/devices") {
+      return { ok: true, json: async () => [] };
+    }
+    if (url === "/api/map/config" && !options.method) {
+      return {
+        ok: true,
+        json: async () => ({
+          floorplan_image_data_url: null,
+          geo_bounds: { min_lat: -23.5515, max_lat: -23.5495, min_lon: -46.6345, max_lon: -46.632 },
+        }),
+      };
+    }
+    if (url === "/api/drones/command") {
+      return { ok: true, json: async () => ({ status: "ok" }) };
+    }
+    if (url === "/api/map/config" && options.method === "PUT") {
+      return { ok: true, json: async () => ({ status: "ok" }) };
+    }
+    return { ok: true, json: async () => ({}) };
+  });
+}
+
+describe("OperationalMap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaultApiFetch();
+  });
+
+  it("sends drone command and shows success message", async () => {
+    render(<OperationalMap />);
+    fireEvent.click(await screen.findByText("Start Patrol"));
+
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith(
+        "/api/drones/command",
+        expect.objectContaining({ method: "POST" }),
+      ),
+    );
+    expect(screen.getByText(/Comando enviado:/)).toBeInTheDocument();
+  });
+
+  it("shows error feedback when drone command fails", async () => {
+    apiFetch.mockImplementation(async (url) => {
+      if (url === "/api/map/devices" || url === "/api/map/config") {
+        return { ok: true, json: async () => ({ floorplan_image_data_url: null, geo_bounds: null }) };
+      }
+      if (url === "/api/drones/command") {
+        return { ok: false, json: async () => ({}) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    render(<OperationalMap />);
+    fireEvent.click(await screen.findByText("Start Patrol"));
+
+    await waitFor(() => expect(screen.getByText("Falha ao enviar comando.")).toBeInTheDocument());
+  });
+
+  it("shows error feedback when map save fails", async () => {
+    class MockFileReader {
+      constructor() {
+        this.result = "data:image/png;base64,AAA";
+      }
+      readAsDataURL() {
+        queueMicrotask(() => this.onload && this.onload());
+      }
+    }
+    global.FileReader = MockFileReader;
+
+    apiFetch.mockImplementation(async (url, options = {}) => {
+      if (url === "/api/map/devices") {
+        return { ok: true, json: async () => [] };
+      }
+      if (url === "/api/map/config" && !options.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            floorplan_image_data_url: null,
+            geo_bounds: { min_lat: -23.5515, max_lat: -23.5495, min_lon: -46.6345, max_lon: -46.632 },
+          }),
+        };
+      }
+      if (url === "/api/map/config" && options.method === "PUT") {
+        return { ok: false, json: async () => ({}) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    const { container } = render(<OperationalMap />);
+    const input = container.querySelector('input[type="file"]');
+    fireEvent.change(input, {
+      target: { files: [new File(["x"], "floorplan.png", { type: "image/png" })] },
+    });
+
+    await waitFor(() => expect(screen.getByText("Falha ao salvar planta.")).toBeInTheDocument());
+  });
+});

--- a/src/dashboard/frontend/src/hooks/useWebSocket.test.jsx
+++ b/src/dashboard/frontend/src/hooks/useWebSocket.test.jsx
@@ -50,6 +50,10 @@ describe("useWebSocket", () => {
     global.WebSocket = MockWebSocket;
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("opens socket and updates ws status", async () => {
     window.sessionStorage.setItem("dashboard_api_key", "browser-token");
     render(<TestComponent />);
@@ -58,5 +62,56 @@ describe("useWebSocket", () => {
     expect(MockWebSocket.instances[0].url).toContain("/ws?token=browser-token");
     expect(setWsStatus).toHaveBeenCalledWith("connecting");
     expect(setWsStatus).toHaveBeenCalledWith("connected");
+  });
+
+  it("handles initial state and state_changed messages", async () => {
+    render(<TestComponent />);
+    await Promise.resolve();
+    const ws = MockWebSocket.instances[0];
+
+    ws.onmessage({
+      data: JSON.stringify({
+        type: "initial_state",
+        states: { "binary_sensor.porta_entrada": { state: "off" } },
+      }),
+    });
+    ws.onmessage({
+      data: JSON.stringify({
+        type: "state_changed",
+        entity_id: "binary_sensor.porta_entrada",
+        old_state: "off",
+        new_state: "on",
+        attributes: { friendly_name: "Porta Entrada" },
+        last_changed: "2026-03-02T16:00:00Z",
+      }),
+    });
+
+    expect(setStates).toHaveBeenCalledWith({
+      "binary_sensor.porta_entrada": { state: "off" },
+    });
+    expect(updateState).toHaveBeenCalledWith(
+      "binary_sensor.porta_entrada",
+      expect.objectContaining({ state: "on" }),
+    );
+    expect(addAlert).toHaveBeenCalled();
+  });
+
+  it("ignores malformed websocket payloads", async () => {
+    render(<TestComponent />);
+    await Promise.resolve();
+    const ws = MockWebSocket.instances[0];
+    ws.onmessage({ data: "{invalid-json" });
+    expect(setStates).not.toHaveBeenCalled();
+    expect(updateState).not.toHaveBeenCalled();
+  });
+
+  it("reconnects after close with backoff", async () => {
+    vi.useFakeTimers();
+    render(<TestComponent />);
+    await Promise.resolve();
+    const first = MockWebSocket.instances[0];
+    first.onclose();
+    vi.advanceTimersByTime(1000);
+    expect(MockWebSocket.instances.length).toBe(2);
   });
 });

--- a/src/dashboard/frontend/vitest.config.js
+++ b/src/dashboard/frontend/vitest.config.js
@@ -15,9 +15,6 @@ export default defineConfig({
         "src/**/*.test.*",
         "src/main.jsx",
         "src/test/**",
-        "src/pages/AssetsAdmin.jsx",
-        "src/components/OperationalMap.jsx",
-        "src/hooks/useWebSocket.js",
       ],
       thresholds: {
         lines: 90,

--- a/wiki/Issue-Resolution-Log.md
+++ b/wiki/Issue-Resolution-Log.md
@@ -39,3 +39,4 @@ Registro cronológico de fechamento das issues de pendências documentais e de c
 | #720 | high | `src/dashboard/backend/app/routers/alerts.py`, `tests/backend/test_map_config_rbac.py`, `src/dashboard/frontend/src/components/OperationalMap.jsx` | fechado | 2026-03-02 |
 | #721 | high | `k8s/base/dashboard/dashboard.yaml`, `scripts/check-k8s-non-root-policy.sh`, `.github/workflows/validate.yml` | fechado | 2026-03-02 |
 | #722 | medium | `.gitignore`, `scripts/check-generated-artifacts.sh`, `.github/workflows/validate.yml` | fechado | 2026-03-02 |
+| #723 | high | `src/dashboard/frontend/vitest.config.js`, `src/dashboard/frontend/src/components/OperationalMap.test.jsx`, `src/dashboard/frontend/src/hooks/useWebSocket.test.jsx` | fechado | 2026-03-02 |

--- a/wiki/Testes-e-Validacao.md
+++ b/wiki/Testes-e-Validacao.md
@@ -236,6 +236,10 @@ O gate de compliance inclui também contratos de documentação operacional:
   - statements >= 85
   - branches >= 60
 
+Atualização 2026-03-02 (Issue #723):
+- Os caminhos críticos `src/pages/AssetsAdmin.jsx`, `src/components/OperationalMap.jsx` e `src/hooks/useWebSocket.js` voltaram ao cálculo de cobertura (remoção de exclusões no `vitest.config.js`).
+- Foram adicionados testes cobrindo cenários de sucesso/erro em comandos e persistência do mapa operacional, além de reconexão e parsing no hook WebSocket.
+
 **Pipeline de segurança:**
 - Workflow `Snyk Security` com execução condicional quando `SNYK_TOKEN` está disponível.
 - Scans de SAST, SCA, IaC e imagens de container (modo não-bloqueante em cenários sem secret).


### PR DESCRIPTION
## Resumo
Resolve a issue #723 fechando lacunas de cobertura nos caminhos críticos do frontend.

## Mudanças
- remove exclusões de cobertura para:
  - src/pages/AssetsAdmin.jsx
  - src/components/OperationalMap.jsx
  - src/hooks/useWebSocket.js
- amplia testes de `useWebSocket` para cenários de:
  - processamento de `initial_state` e `state_changed`
  - payload inválido
  - reconexão com backoff
- adiciona `OperationalMap.test.jsx` cobrindo:
  - envio de comando com sucesso
  - erro no envio de comando
  - erro ao salvar configuração do mapa
- atualiza wiki de testes e log de resolução

## Validação local
- não foi possível executar Vitest neste ambiente (dependências frontend não instaladas)

Closes #723
